### PR TITLE
Scorpio::JSON::Node and typelike module improvements

### DIFF
--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -77,6 +77,16 @@ module Scorpio
         Node.new_by_type(document, [])
       end
 
+      # the parent of this node. if this node is the document root (its path is empty), raises
+      # ::JSON::Schema::Pointer::ReferenceError.
+      def parent_node
+        if path.empty?
+          raise(::JSON::Schema::Pointer::ReferenceError, "cannot access parent of root node:\n#{pretty_inspect.chomp}")
+        else
+          Node.new_by_type(document, path[0...-1])
+        end
+      end
+
       def pointer_path
         pointer.pointer
       end

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -137,7 +137,7 @@ module Scorpio
       end
 
       def fingerprint
-        {class: self.class, document: document, path: path}
+        {is_node: self.is_a?(Scorpio::JSON::Node), document: document, path: path}
       end
       include FingerprintHash
     end

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -173,9 +173,13 @@ module Scorpio
     end
 
     class HashNode < Node
-      def each
+      def each(&block)
         return to_enum(__method__) { content.size } unless block_given?
-        content.each_key { |k| yield k, self[k] }
+        if block.arity > 1
+          content.each_key { |k| yield k, self[k] }
+        else
+          content.each_key { |k| yield [k, self[k]] }
+        end
         self
       end
       include Enumerable

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -116,6 +116,10 @@ module Scorpio
         pointer.fragment
       end
 
+      def as_json
+        content.as_json
+      end
+
       # takes a block. the block is yielded the content of this node. the block MUST return a modified
       # copy of that content (and NOT modify the object it is given).
       def modified_copy
@@ -198,6 +202,10 @@ module Scorpio
 
       include Arraylike
 
+      def as_json # needs redefined after including Enumerable
+        content.as_json
+      end
+
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_a).
       # we override these methods from Arraylike
       SAFE_INDEX_ONLY_METHODS.each do |method_name|
@@ -230,6 +238,10 @@ module Scorpio
       end
 
       include Hashlike
+
+      def as_json # needs redefined after including Enumerable
+        content.as_json
+      end
 
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_hash)
       SAFE_KEY_ONLY_METHODS.each do |method_name|

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -32,7 +32,7 @@ module Scorpio
       # a Node represents the content of a document at a given path.
       def initialize(document, path)
         raise(ArgumentError, "path must be an array. got: #{path.pretty_inspect} (#{path.class})") unless path.is_a?(Array)
-        define_singleton_method(:document) { document }
+        @document = document
         @path = path.dup.freeze
         @pointer = ::JSON::Schema::Pointer.new(:reference_tokens, path)
       end

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -191,7 +191,6 @@ module Scorpio
         content.each_index { |i| yield self[i] }
         self
       end
-      include Enumerable
 
       def to_ary
         to_a
@@ -225,7 +224,6 @@ module Scorpio
         end
         self
       end
-      include Enumerable
 
       def to_hash
         inject({}) { |h, (k, v)| h[k] = v; h }

--- a/lib/scorpio/model.rb
+++ b/lib/scorpio/model.rb
@@ -496,6 +496,10 @@ module Scorpio
       @attributes
     end
 
+    def as_json
+      @attributes.as_json
+    end
+
     def inspect
       "\#<#{self.class.name} #{attributes.inspect}>"
     end

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -92,7 +92,6 @@ module Scorpio
       object.each_key { |k| yield(k, self[k]) }
       self
     end
-    include Enumerable
 
     def to_hash
       inject({}) { |h, (k, v)| h[k] = v; h }
@@ -157,7 +156,6 @@ module Scorpio
       object.each_index { |i| yield(self[i]) }
       self
     end
-    include Enumerable
 
     def to_ary
       to_a

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -15,6 +15,8 @@ module Scorpio
       elsif module_schema.describes_array? && @object.is_a?(Scorpio::JSON::ArrayNode)
         extend SchemaObjectBaseArray
       end
+      # as_json needs to be defined after we are extended by Enumerable
+      define_singleton_method(:as_json) { object.as_json }
     end
 
     attr_reader :object

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -101,19 +101,9 @@ module Scorpio
     include Hashlike
     include SchemaObjectMightBeLike
 
-    # hash methods - define only those which do not modify the hash.
-
-    # methods that don't look at the value; can skip the overhead of #[]
-    key_methods = %w(each_key empty? include? has_key? key key? keys length member? size)
-    key_methods.each do |method_name|
+    # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_hash)
+    SAFE_KEY_ONLY_METHODS.each do |method_name|
       define_method(method_name) { |*a, &b| object.public_send(method_name, *a, &b) }
-    end
-
-    # methods which use key and value
-    hash_methods = %w(compact each_pair each_value fetch fetch_values has_value? invert
-      rassoc reject select to_h transform_values value? values values_at)
-    hash_methods.each do |method_name|
-      define_method(method_name) { |*a, &b| to_hash.public_send(method_name, *a, &b) }
     end
 
     def [](property_name_)
@@ -175,6 +165,12 @@ module Scorpio
 
     include Arraylike
     include SchemaObjectMightBeLike
+
+    # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_a).
+    # we override these methods from Arraylike
+    SAFE_INDEX_ONLY_METHODS.each do |method_name|
+      define_method(method_name) { |*a, &b| OBJECT.public_send(method_name, *a, &b) }
+    end
 
     def [](i_)
       # it would make more sense for this to be an array here, but but Array doesn't have a nice memoizing

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -56,7 +56,7 @@ module Scorpio
     # methods which do not need to access the element.
     SAFE_INDEX_ONLY_METHODS = %w(each_index empty? length size)
     # there are some ambiguous ones that are omitted, like #sort, #map / #collect.
-    SAFE_INDEX_ELEMENT_METHODS = %w(| & * + - <=> abbrev assoc at bsearch bsearch_index combination compact count cycle dig drop drop_while fetch find_index first include? index join last pack permutation product rassoc reject repeated_combination repeated_permutation reverse reverse_each rindex rotate sample select shelljoin shuffle slice sort take take_while transpose uniq values_at zip)
+    SAFE_INDEX_ELEMENT_METHODS = %w(| & * + - <=> abbrev assoc at bsearch bsearch_index combination compact count cycle dig drop drop_while fetch find_index first include? index join last pack permutation product reject repeated_combination repeated_permutation reverse reverse_each rindex rotate sample select shelljoin shuffle slice sort take take_while transpose uniq values_at zip)
     DESTRUCTIVE_METHODS = %w(<< clear collect! compact! concat delete delete_at delete_if fill flatten! insert keep_if map! pop push reject! replace reverse! rotate! select! shift shuffle! slice! sort! sort_by! uniq! unshift)
     # methods which return a modified copy, which you'd expect to be of the same class as the receiver.
     SAFE_MODIFIED_COPY_METHODS = %w(compact reject select)

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -1,5 +1,16 @@
 module Scorpio
   module Hashlike
+    # safe methods which can be delegated to #to_hash (which the includer is assumed to have defined).
+    # 'safe' means, in this context, nondestructive - methods which do not modify the receiver.
+
+    # methods which do not need to access the value.
+    SAFE_KEY_ONLY_METHODS = %w(each_key empty? has_key? include? key? keys length member? size)
+    SAFE_KEY_VALUE_METHODS = %w(< <= > >= any? assoc compact dig each_pair each_value fetch fetch_values has_value? invert key merge rassoc reject select to_h to_proc transform_values value? values values_at)
+    DESTRUCTIVE_METHODS = %w(clear delete delete_if keep_if reject! replace select! shift)
+    # methods which return a modified copy, which you'd expect to be of the same class as the receiver.
+    # there are some ambiguous ones that are omitted, like #invert.
+    SAFE_MODIFIED_COPY_METHODS = %w(compact merge reject select transform_values)
+
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''
       "\#{<#{self.class.name}#{object_group_text}> #{self.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(', ')}}"

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -38,6 +38,17 @@ module Scorpio
     end
   end
   module Arraylike
+    # safe methods which can be delegated to #to_ary (which the includer is assumed to have defined).
+    # 'safe' means, in this context, nondestructive - methods which do not modify the receiver.
+
+    # methods which do not need to access the element.
+    SAFE_INDEX_ONLY_METHODS = %w(each_index empty? length size)
+    # there are some ambiguous ones that are omitted, like #sort, #map / #collect.
+    SAFE_INDEX_ELEMENT_METHODS = %w(| & * + - <=> abbrev assoc at bsearch bsearch_index combination compact count cycle dig drop drop_while fetch find_index first include? index join last pack permutation product rassoc reject repeated_combination repeated_permutation reverse reverse_each rindex rotate sample select shelljoin shuffle slice sort take take_while transpose uniq values_at zip)
+    DESTRUCTIVE_METHODS = %w(<< clear collect! compact! concat delete delete_at delete_if fill flatten! insert keep_if map! pop push reject! replace reverse! rotate! select! shift shuffle! slice! sort! sort_by! uniq! unshift)
+    # methods which return a modified copy, which you'd expect to be of the same class as the receiver.
+    SAFE_MODIFIED_COPY_METHODS = %w(compact reject select)
+
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''
       "\#[<#{self.class.name}#{object_group_text}> #{self.map { |e| e.inspect }.join(', ')}]"

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -1,5 +1,7 @@
 module Scorpio
   module Hashlike
+    include Enumerable
+
     # safe methods which can be delegated to #to_hash (which the includer is assumed to have defined).
     # 'safe' means, in this context, nondestructive - methods which do not modify the receiver.
 
@@ -42,6 +44,8 @@ module Scorpio
     end
   end
   module Arraylike
+    include Enumerable
+
     # safe methods which can be delegated to #to_ary (which the includer is assumed to have defined).
     # 'safe' means, in this context, nondestructive - methods which do not modify the receiver.
 

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -22,6 +22,10 @@ module Scorpio
       "\#{<#{self.class.name}#{object_group_text}> #{self.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(', ')}}"
     end
 
+    def to_s
+      inspect
+    end
+
     def pretty_print(q)
       q.instance_exec(self) do |obj|
         object_group_text = obj.respond_to?(:object_group_text) ? ' ' + obj.object_group_text : ''
@@ -65,6 +69,10 @@ module Scorpio
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''
       "\#[<#{self.class.name}#{object_group_text}> #{self.map { |e| e.inspect }.join(', ')}]"
+    end
+
+    def to_s
+      inspect
     end
 
     def pretty_print(q)

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -10,6 +10,10 @@ module Scorpio
     # methods which return a modified copy, which you'd expect to be of the same class as the receiver.
     # there are some ambiguous ones that are omitted, like #invert.
     SAFE_MODIFIED_COPY_METHODS = %w(compact merge reject select transform_values)
+    SAFE_METHODS = SAFE_KEY_ONLY_METHODS | SAFE_KEY_VALUE_METHODS
+    SAFE_METHODS.each do |method_name|
+      define_method(method_name) { |*a, &b| to_hash.public_send(method_name, *a, &b) }
+    end
 
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''
@@ -48,6 +52,11 @@ module Scorpio
     DESTRUCTIVE_METHODS = %w(<< clear collect! compact! concat delete delete_at delete_if fill flatten! insert keep_if map! pop push reject! replace reverse! rotate! select! shift shuffle! slice! sort! sort_by! uniq! unshift)
     # methods which return a modified copy, which you'd expect to be of the same class as the receiver.
     SAFE_MODIFIED_COPY_METHODS = %w(compact reject select)
+
+    SAFE_METHODS = SAFE_INDEX_ONLY_METHODS | SAFE_INDEX_ELEMENT_METHODS
+    SAFE_METHODS.each do |method_name|
+      define_method(method_name) { |*a, &b| to_ary.public_send(method_name, *a, &b) }
+    end
 
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''

--- a/test/schema_object_base_test.rb
+++ b/test/schema_object_base_test.rb
@@ -1,5 +1,11 @@
 require_relative 'test_helper'
 
 describe Scorpio::SchemaObjectBase do
-
+  describe '#as_json' do
+    it '#as_json' do
+      assert_equal({'a' => 'b'}, Scorpio.class_for_schema(Scorpio::JSON::Node.new_by_type({}, [])).new({'a' => 'b'}).as_json)
+      assert_equal({'a' => 'b'}, Scorpio.class_for_schema(Scorpio::JSON::Node.new_by_type({'type' => 'object'}, [])).new({'a' => 'b'}).as_json)
+      assert_equal(['a', 'b'], Scorpio.class_for_schema(Scorpio::JSON::Node.new_by_type({'type' => 'array'}, [])).new(['a', 'b']).as_json)
+    end
+  end
 end

--- a/test/schema_object_base_test.rb
+++ b/test/schema_object_base_test.rb
@@ -1,0 +1,5 @@
+require_relative 'test_helper'
+
+describe Scorpio::SchemaObjectBase do
+
+end

--- a/test/scorpio_json_arraynode_test.rb
+++ b/test/scorpio_json_arraynode_test.rb
@@ -70,6 +70,14 @@ describe Scorpio::JSON::ArrayNode do
     it('#pack')                 { assert_equal(' ', Scorpio::JSON::Node.new_by_type([32], []).pack('c')) }
     it('#permutation')          { assert_equal([['a'], [node[1]], [node[2]]], node.permutation(1).to_a) }
     it('#product')              { assert_equal([], node.product([])) }
+    # due to differences in implementation between #assoc and #rassoc, the reason for which
+    # I cannot begin to fathom, assoc works but rassoc does not because rassoc has different
+    # type checking than assoc for the array(like) array elements.
+    # compare:
+    # assoc:  https://github.com/ruby/ruby/blob/v2_5_0/array.c#L3780-L3813
+    # rassoc: https://github.com/ruby/ruby/blob/v2_5_0/array.c#L3815-L3847
+    # for this reason, rassoc is NOT defined on Arraylike and #content must be called.
+    it('#rassoc')               { assert_equal(['b', 'q'], node.content.rassoc('q')) }
     it('#repeated_combination') { assert_equal([[]], node.repeated_combination(0).to_a) }
     it('#repeated_permutation') { assert_equal([[]], node.repeated_permutation(0).to_a) }
     it('#reverse')              { assert_equal([node[2], node[1], 'a'], node.reverse) }

--- a/test/scorpio_json_arraynode_test.rb
+++ b/test/scorpio_json_arraynode_test.rb
@@ -53,11 +53,11 @@ describe Scorpio::JSON::ArrayNode do
     it('#assoc')                { assert_equal(['b', 'q'], node.assoc('b')) }
     it('#at')                   { assert_equal('a', node.at(0)) }
     it('#bsearch')              { assert_equal(nil, node.bsearch { false }) }
-    it('#bsearch_index')        { assert_equal(nil, node.bsearch_index { false }) }
+    it('#bsearch_index')        { assert_equal(nil, node.bsearch_index { false }) } if [].respond_to?(:bsearch_index)
     it('#combination')          { assert_equal([['a'], [node[1]], [node[2]]], node.combination(1).to_a) }
     it('#count')                { assert_equal(1, node.count('a')) }
     it('#cycle')                { assert_equal(node.to_a, node.cycle(1).to_a) }
-    it('#dig')                  { assert_equal('e', node.dig(2, 'c', 'd')) }
+    it('#dig')                  { assert_equal('e', node.dig(2, 'c', 'd')) } if [].respond_to?(:dig)
     it('#drop')                 { assert_equal([node[2]], node.drop(2)) }
     it('#drop_while')           { assert_equal([node[1], node[2]], node.drop_while { |e| e == 'a' }) }
     it('#fetch')                { assert_equal('a', node.fetch(0)) }
@@ -85,7 +85,7 @@ describe Scorpio::JSON::ArrayNode do
     it('#rindex')               { assert_equal(0, node.rindex('a')) }
     it('#rotate')               { assert_equal([node[1], node[2], 'a'], node.rotate) }
     it('#sample')               { assert_equal('a', Scorpio::JSON::Node.new_by_type(['a'], []).sample) }
-    it('#shelljoin')            { assert_equal('a', Scorpio::JSON::Node.new_by_type(['a'], []).shelljoin) }
+    it('#shelljoin')            { assert_equal('a', Scorpio::JSON::Node.new_by_type(['a'], []).shelljoin) } if [].respond_to?(:shelljoin)
     it('#shuffle')              { assert_equal(3, node.shuffle.size) }
     it('#slice')                { assert_equal(['a'], node.slice(0, 1)) }
     it('#sort')                 { assert_equal(['a'], Scorpio::JSON::Node.new_by_type(['a'], []).sort) }

--- a/test/scorpio_json_arraynode_test.rb
+++ b/test/scorpio_json_arraynode_test.rb
@@ -33,4 +33,69 @@ describe Scorpio::JSON::ArrayNode do
       assert_equal(['a', node[1], node[2]], node.to_ary)
     end
   end
+  # these methods just delegate to Array so not going to test excessively
+  describe 'index only methods' do
+    it('#each_index') { assert_equal([0, 1, 2], node.each_index.to_a) }
+    it('#empty?')     { assert_equal(false, node.empty?) }
+    it('#length')     { assert_equal(3, node.length) }
+    it('#size')       { assert_equal(3, node.size) }
+  end
+  describe 'index + element methods' do
+    it('#|')                    { assert_equal(['a', node[1], node[2], 0], node | [0]) }
+    it('#&')                    { assert_equal(['a'], node & ['a']) }
+    it('#*')                    { assert_equal(node.to_a, node * 1) }
+    it('#+')                    { assert_equal(node.to_a, node + []) }
+    it('#-')                    { assert_equal([node[1], node[2]], node - ['a']) }
+    it('#<=>')                  { assert_equal(1, node <=> []) }
+    it('#<=>')                  { assert_equal(-1, [] <=> node) }
+    require 'abbrev'
+    it('#abbrev')               { assert_equal({'a' => 'a'}, Scorpio::JSON::Node.new_by_type(['a'], []).abbrev) }
+    it('#assoc')                { assert_equal(['b', 'q'], node.assoc('b')) }
+    it('#at')                   { assert_equal('a', node.at(0)) }
+    it('#bsearch')              { assert_equal(nil, node.bsearch { false }) }
+    it('#bsearch_index')        { assert_equal(nil, node.bsearch_index { false }) }
+    it('#combination')          { assert_equal([['a'], [node[1]], [node[2]]], node.combination(1).to_a) }
+    it('#count')                { assert_equal(1, node.count('a')) }
+    it('#cycle')                { assert_equal(node.to_a, node.cycle(1).to_a) }
+    it('#dig')                  { assert_equal('e', node.dig(2, 'c', 'd')) }
+    it('#drop')                 { assert_equal([node[2]], node.drop(2)) }
+    it('#drop_while')           { assert_equal([node[1], node[2]], node.drop_while { |e| e == 'a' }) }
+    it('#fetch')                { assert_equal('a', node.fetch(0)) }
+    it('#find_index')           { assert_equal(0, node.find_index { true }) }
+    it('#first')                { assert_equal('a', node.first) }
+    it('#include?')             { assert_equal(true, node.include?('a')) }
+    it('#index')                { assert_equal(0, node.index('a')) }
+    it('#join')                 { assert_equal('a b', Scorpio::JSON::Node.new_by_type(['a', 'b'], []).join(' ')) }
+    it('#last')                 { assert_equal(node[2], node.last) }
+    it('#pack')                 { assert_equal(' ', Scorpio::JSON::Node.new_by_type([32], []).pack('c')) }
+    it('#permutation')          { assert_equal([['a'], [node[1]], [node[2]]], node.permutation(1).to_a) }
+    it('#product')              { assert_equal([], node.product([])) }
+    it('#repeated_combination') { assert_equal([[]], node.repeated_combination(0).to_a) }
+    it('#repeated_permutation') { assert_equal([[]], node.repeated_permutation(0).to_a) }
+    it('#reverse')              { assert_equal([node[2], node[1], 'a'], node.reverse) }
+    it('#reverse_each')         { assert_equal([node[2], node[1], 'a'], node.reverse_each.to_a) }
+    it('#rindex')               { assert_equal(0, node.rindex('a')) }
+    it('#rotate')               { assert_equal([node[1], node[2], 'a'], node.rotate) }
+    it('#sample')               { assert_equal('a', Scorpio::JSON::Node.new_by_type(['a'], []).sample) }
+    it('#shelljoin')            { assert_equal('a', Scorpio::JSON::Node.new_by_type(['a'], []).shelljoin) }
+    it('#shuffle')              { assert_equal(3, node.shuffle.size) }
+    it('#slice')                { assert_equal(['a'], node.slice(0, 1)) }
+    it('#sort')                 { assert_equal(['a'], Scorpio::JSON::Node.new_by_type(['a'], []).sort) }
+    it('#take')                 { assert_equal(['a'], node.take(1)) }
+    it('#take_while')           { assert_equal([], node.take_while { false }) }
+    it('#transpose')            { assert_equal([], Scorpio::JSON::Node.new_by_type([], []).transpose) }
+    it('#uniq')                 { assert_equal(node.to_a, node.uniq) }
+    it('#values_at')            { assert_equal(['a'], node.values_at(0)) }
+    it('#zip')                  { assert_equal([['a', 'a'], [node[1], node[1]], [node[2], node[2]]], node.zip(node)) }
+  end
+  describe 'modified copy methods' do
+    it('#reject')  { assert_equal(Scorpio::JSON::Node.new_by_type(['a'], []), node.reject { |e| e != 'a' }) }
+    it('#select')  { assert_equal(Scorpio::JSON::Node.new_by_type(['a'], []), node.select { |e| e == 'a' }) }
+    it('#compact') { assert_equal(node, node.compact) }
+  end
+  Scorpio::Arraylike::DESTRUCTIVE_METHODS.each do |destructive_method_name|
+    it("does not respond to destructive method #{destructive_method_name}") do
+      assert(!node.respond_to?(destructive_method_name))
+    end
+  end
 end

--- a/test/scorpio_json_arraynode_test.rb
+++ b/test/scorpio_json_arraynode_test.rb
@@ -33,6 +33,12 @@ describe Scorpio::JSON::ArrayNode do
       assert_equal(['a', node[1], node[2]], node.to_ary)
     end
   end
+  describe '#as_json' do
+    let(:document) { ['a', 'b'] }
+    it '#as_json' do
+      assert_equal(['a', 'b'], node.as_json)
+    end
+  end
   # these methods just delegate to Array so not going to test excessively
   describe 'index only methods' do
     it('#each_index') { assert_equal([0, 1, 2], node.each_index.to_a) }

--- a/test/scorpio_json_arraynode_test.rb
+++ b/test/scorpio_json_arraynode_test.rb
@@ -1,0 +1,36 @@
+require_relative 'test_helper'
+
+describe Scorpio::JSON::ArrayNode do
+  # document of the node being tested
+  let(:document) { ['a', ['b', 'q'], {'c' => {'d' => 'e'}}] }
+  # by default the node is the whole document
+  let(:path) { [] }
+  # the node being tested
+  let(:node) { Scorpio::JSON::Node.new_by_type(document, path) }
+
+  describe '#each' do
+    it 'iterates, one argument' do
+      out = []
+      node.each do |arg|
+        out << arg
+      end
+      assert_instance_of(Scorpio::JSON::ArrayNode, node[1])
+      assert_instance_of(Scorpio::JSON::HashNode, node[2])
+      assert_equal(['a', node[1], node[2]], out)
+    end
+    it 'returns self' do
+      assert_equal(node.each { }.object_id, node.object_id)
+    end
+    it 'returns an enumerator when called with no block' do
+      enum = node.each
+      assert_instance_of(Enumerator, enum)
+      assert_equal(['a', node[1], node[2]], enum.to_a)
+    end
+  end
+  describe '#to_ary' do
+    it 'returns a Array with Nodes in' do
+      assert_instance_of(Array, node.to_ary)
+      assert_equal(['a', node[1], node[2]], node.to_ary)
+    end
+  end
+end

--- a/test/scorpio_json_hashnode_test.rb
+++ b/test/scorpio_json_hashnode_test.rb
@@ -54,6 +54,12 @@ describe Scorpio::JSON::HashNode do
       assert_equal(node.document['a'].object_id, merged.document['a'].object_id)
     end
   end
+  describe '#as_json' do
+    let(:document) { {'a' => 'b'} }
+    it '#as_json' do
+      assert_equal({'a' => 'b'}, node.as_json)
+    end
+  end
   # these methods just delegate to Hash so not going to test excessively
   describe 'key only methods' do
     it('#each_key') { assert_equal(['a', 'c'], node.each_key.to_a) }

--- a/test/scorpio_json_hashnode_test.rb
+++ b/test/scorpio_json_hashnode_test.rb
@@ -1,0 +1,64 @@
+require_relative 'test_helper'
+
+describe Scorpio::JSON::HashNode do
+  # document of the node being tested
+  let(:document) { {'a' => 'b', 'c' => {'d' => 'e'}} }
+  # by default the node is the whole document
+  let(:path) { [] }
+  # the node being tested
+  let(:node) { Scorpio::JSON::Node.new_by_type(document, path) }
+
+  describe '#each' do
+    it 'iterates, one argument' do
+      out = []
+      node.each do |arg|
+        out << arg
+      end
+      assert_instance_of(Scorpio::JSON::HashNode, node['c'])
+      assert_equal([['a', 'b'], ['c', node['c']]], out)
+    end
+    it 'iterates, two arguments' do
+      out = []
+      retval = node.each do |k, v|
+        out << [k, v]
+      end
+      assert_instance_of(Scorpio::JSON::HashNode, node['c'])
+      assert_equal([['a', 'b'], ['c', node['c']]], out)
+    end
+    it 'returns self' do
+      assert_equal(node.each { }.object_id, node.object_id)
+    end
+    it 'returns an enumerator when called with no block' do
+      enum = node.each
+      assert_instance_of(Enumerator, enum)
+      assert_equal([['a', 'b'], ['c', node['c']]], enum.to_a)
+    end
+  end
+  describe '#to_hash' do
+    it 'returns a Hash with Nodes in' do
+      assert_instance_of(Hash, node.to_hash)
+      assert_equal({'a' => 'b', 'c' => node['c']}, node.to_hash)
+    end
+  end
+  describe '#merge' do
+    let(:document) { {'a' => {'b' => 0}, 'c' => {'d' => 'e'}} }
+    # testing the node at 'c' here, merging a hash at a path within a document.
+    let(:path) { ['c'] }
+    it 'merges' do
+      merged = node.merge('x' => 'y')
+      # check the content at 'c' was merged with the remainder of the document intact (at 'a')
+      assert_equal({'a' => {'b' => 0}, 'c' => {'d' => 'e', 'x' => 'y'}}, merged.document)
+      # check the original node retains its original document
+      assert_equal({'a' => {'b' => 0}, 'c' => {'d' => 'e'}}, node.document)
+      # check that unnecessary copies of unaffected parts of the document were not made
+      assert_equal(node.document['a'].object_id, merged.document['a'].object_id)
+    end
+  end
+  # these methods just delegate to Hash so not going to test excessively
+  describe 'key only methods' do
+    it('#each_key') { assert_equal(['a', 'c'], node.each_key.to_a) }
+  end
+  describe 'key + value methods' do
+    it('#any?') { assert_equal(true, node.any? { |k, v| k == 'a' }) }
+  end
+end

--- a/test/scorpio_json_hashnode_test.rb
+++ b/test/scorpio_json_hashnode_test.rb
@@ -57,8 +57,52 @@ describe Scorpio::JSON::HashNode do
   # these methods just delegate to Hash so not going to test excessively
   describe 'key only methods' do
     it('#each_key') { assert_equal(['a', 'c'], node.each_key.to_a) }
+    it('#empty?')   { assert_equal(false, node.empty?) }
+    it('#has_key?') { assert_equal(true, node.has_key?('a')) }
+    it('#include?') { assert_equal(false, node.include?('q')) }
+    it('#key?')     { assert_equal(true, node.key?('c')) }
+    it('#keys')     { assert_equal(['a', 'c'], node.keys) }
+    it('#length')   { assert_equal(2, node.length) }
+    it('#member?')  { assert_equal(false, node.member?(0)) }
+    it('#size')     { assert_equal(2, node.size) }
   end
   describe 'key + value methods' do
-    it('#any?') { assert_equal(true, node.any? { |k, v| k == 'a' }) }
+    it('#<')            { assert_equal(true, node < {'a' => 'b', 'c' => node['c'], 'x' => 'y'}) } if {}.respond_to?(:<)
+    it('#<=')           { assert_equal(true, node <= node) } if {}.respond_to?(:<=)
+    it('#>')            { assert_equal(true, node > {}) } if {}.respond_to?(:>)
+    it('#>=')           { assert_equal(false, node >= {'foo' => 'bar'}) } if {}.respond_to?(:>=)
+    it('#any?')         { assert_equal(false, node.any? { |k, v| v == 3 }) }
+    it('#assoc')        { assert_equal(['a', 'b'], node.assoc('a')) }
+    it('#dig')          { assert_equal('e', node.dig('c', 'd')) } if {}.respond_to?(:dig)
+    it('#each_pair')    { assert_equal([['a', 'b'], ['c', node['c']]], node.each_pair.to_a) }
+    it('#each_value')   { assert_equal(['b', node['c']], node.each_value.to_a) }
+    it('#fetch')        { assert_equal('b', node.fetch('a')) }
+    it('#fetch_values') { assert_equal(['b'], node.fetch_values('a')) } if {}.respond_to?(:fetch_values)
+    it('#has_value?')   { assert_equal(true, node.has_value?('b')) }
+    it('#invert')       { assert_equal({'b' => 'a', node['c'] => 'c'}, node.invert) }
+    it('#key')          { assert_equal('a', node.key('b')) }
+    it('#rassoc')       { assert_equal(['a', 'b'], node.rassoc('b')) }
+    it('#to_h')         { assert_equal({'a' => 'b', 'c' => node['c']}, node.to_h) }
+    it('#to_proc')      { assert_equal('b', node.to_proc.call('a')) } if {}.respond_to?(:to_proc)
+    it('#value?')       { assert_equal(false, node.value?('0')) }
+    it('#values')       { assert_equal(['b', node['c']], node.values) }
+    it('#values_at')    { assert_equal(['b'], node.values_at('a')) }
+  end
+  describe 'modified copy methods' do
+    # I'm going to rely on the #merge test above to test the modified copy functionality and just do basic
+    # tests of all the modified copy methods here
+    it('#merge')            { assert_equal(node, node.merge({})) }
+    it('#transform_values') { assert_equal(Scorpio::JSON::Node.new_by_type({'a' => nil, 'c' => nil}, []), node.transform_values { |_| nil}) }
+    it('#reject')           { assert_equal(Scorpio::JSON::Node.new_by_type({}, []), node.reject { true }) }
+    it('#select')           { assert_equal(Scorpio::JSON::Node.new_by_type({}, []), node.select { false }) }
+    # Hash#compact only available as of ruby 2.5.0
+    if {}.respond_to?(:compact)
+      it('#compact')          { assert_equal(node, node.compact) }
+    end
+  end
+  Scorpio::Hashlike::DESTRUCTIVE_METHODS.each do |destructive_method_name|
+    it("does not respond to destructive method #{destructive_method_name}") do
+      assert(!node.respond_to?(destructive_method_name))
+    end
   end
 end

--- a/test/scorpio_json_node_test.rb
+++ b/test/scorpio_json_node_test.rb
@@ -41,6 +41,31 @@ describe Scorpio::JSON::Node do
       assert_equal('b', Scorpio::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], [1, 'x', 0, 'a', 0]).content)
     end
   end
+  describe '#deref' do
+    let(:document) do
+      {
+        'foo' => {'bar' => ['baz']},
+        'a' => {'$ref' => '#/foo'}, # not sure a description is actually allowed here, whatever
+      }
+    end
+    it 'follows a $ref' do
+      assert_equal({'bar' => ['baz']}, node['a'].deref.content)
+    end
+    it 'returns the node when there is no $ref to follow' do
+      assert_equal({'bar' => ['baz']}, node['foo'].deref.content)
+    end
+    describe "dealing with google's invalid $refs" do
+      let(:document) do
+        {
+          'schemas' => {'bar' => ['baz']},
+          'a' => {'$ref' => 'bar'},
+        }
+      end
+      it 'looks for a node in #/schemas with the name of the $ref' do
+        assert_equal(['baz'], node['a'].deref.content)
+      end
+    end
+  end
   describe '#[]' do
     describe 'without dereferencing' do
       let(:document) { [0, {'x' => [{'a' => ['b']}]}] }
@@ -77,10 +102,69 @@ describe Scorpio::JSON::Node do
         assert_equal(['baz'], subscripted.content)
         assert_equal(['foo', 'bar'], subscripted.path)
       end
-      it 'does not follow a $ref when subscripting ' do
+      it 'does not follow a $ref when subscripting a key that is present' do
         subscripted = node['a']['description']
         assert_equal('hi', subscripted)
       end
+    end
+  end
+  describe '#document_node' do
+    let(:document) { {'a' => {'b' => 3}} }
+    it 'has content that is the document' do
+      assert_equal({'a' => {'b' => 3}}, node['a'].document_node.content)
+    end
+  end
+  describe '#pointer_path' do
+    let(:document) { {'a' => {'b' => 3}} }
+    it 'is empty' do
+      assert_equal('', node.pointer_path)
+    end
+    it 'is not empty' do
+      assert_equal('/a', node['a'].pointer_path)
+    end
+    describe 'containing an empty string and some slashes and tildes that need escaping' do
+      let(:document) { {'' => {'a/b~c!d#e[f]' => []}} }
+      it 'matches' do
+        assert_equal('//a~1b~0c!d#e[f]', node['']['a/b~c!d#e[f]'].pointer_path)
+      end
+    end
+  end
+  describe '#fragment' do
+    let(:document) { {'a' => {'b' => 3}} }
+    it 'is empty' do
+      assert_equal('#', node.fragment)
+    end
+    it 'is not empty' do
+      assert_equal('#/a', node['a'].fragment)
+    end
+    describe 'containing an empty string and some slashes and tildes that need escaping' do
+      let(:document) { {'' => {'a/b~c!d#e[f]' => []}} }
+      it 'matches' do
+        assert_equal('#//a~1b~0c!d#e%5Bf%5D', node['']['a/b~c!d#e[f]'].fragment)
+      end
+    end
+  end
+  describe '#fingerprint' do
+    it 'hashes consistently' do
+      assert_equal('x', {Scorpio::JSON::Node.new([0], []) => 'x'}[Scorpio::JSON::Node.new([0], [])])
+    end
+    it 'hashes consistently regardless of the Node being decorated as a subclass' do
+      assert_equal('x', {Scorpio::JSON::Node.new_by_type([0], []) => 'x'}[Scorpio::JSON::Node.new([0], [])])
+      assert_equal('x', {Scorpio::JSON::Node.new([0], []) => 'x'}[Scorpio::JSON::Node.new_by_type([0], [])])
+    end
+    it '==' do
+      assert_equal(Scorpio::JSON::Node.new([0], []), Scorpio::JSON::Node.new([0], []))
+      assert_equal(Scorpio::JSON::Node.new_by_type([0], []), Scorpio::JSON::Node.new([0], []))
+      assert_equal(Scorpio::JSON::Node.new([0], []), Scorpio::JSON::Node.new_by_type([0], []))
+      assert_equal(Scorpio::JSON::Node.new_by_type([0], []), Scorpio::JSON::Node.new_by_type([0], []))
+    end
+    it '!=' do
+      refute_equal(Scorpio::JSON::Node.new([0], []), Scorpio::JSON::Node.new({}, []))
+      refute_equal(Scorpio::JSON::Node.new_by_type([0], []), Scorpio::JSON::Node.new({}, []))
+      refute_equal(Scorpio::JSON::Node.new([0], []), Scorpio::JSON::Node.new_by_type({}, []))
+      refute_equal(Scorpio::JSON::Node.new_by_type([0], []), Scorpio::JSON::Node.new_by_type({}, []))
+      refute_equal({}, Scorpio::JSON::Node.new_by_type({}, []))
+      refute_equal(Scorpio::JSON::Node.new_by_type({}, []), {})
     end
   end
 end

--- a/test/scorpio_json_node_test.rb
+++ b/test/scorpio_json_node_test.rb
@@ -1,6 +1,8 @@
 require_relative 'test_helper'
 
 describe Scorpio::JSON::Node do
+  let(:node) { Scorpio::JSON::Node.new(document, []) }
+
   describe 'initialization' do
     it 'initializes' do
       node = Scorpio::JSON::Node.new({'a' => 'b'}, [])
@@ -41,7 +43,7 @@ describe Scorpio::JSON::Node do
   end
   describe '#[]' do
     describe 'without dereferencing' do
-      let(:node) { Scorpio::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], []) }
+      let(:document) { [0, {'x' => [{'a' => ['b']}]}] }
       it 'subscripts arrays and hashes' do
         assert_equal('b', node[1]['x'][0]['a'][0])
       end
@@ -65,7 +67,6 @@ describe Scorpio::JSON::Node do
           'a' => {'$ref' => '#/foo', 'description' => 'hi'}, # not sure a description is actually allowed here, whatever
         }
       end
-      let(:node) { Scorpio::JSON::Node.new(document, []) }
       it 'subscripts a node consisting of a $ref WITHOUT following' do
         subscripted = node['a']
         assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.content)

--- a/test/scorpio_json_node_test.rb
+++ b/test/scorpio_json_node_test.rb
@@ -1,0 +1,85 @@
+require_relative 'test_helper'
+
+describe Scorpio::JSON::Node do
+  describe 'initialization' do
+    it 'initializes' do
+      node = Scorpio::JSON::Node.new({'a' => 'b'}, [])
+      assert_equal({'a' => 'b'}, node.document)
+      assert_equal([], node.path)
+    end
+  end
+  describe 'initialization by .new_by_type' do
+    it 'initializes HashNode' do
+      node = Scorpio::JSON::Node.new_by_type({'a' => 'b'}, [])
+      assert_instance_of(Scorpio::JSON::HashNode, node)
+      assert_equal({'a' => 'b'}, node.document)
+    end
+    it 'initializes ArrayNode' do
+      node = Scorpio::JSON::Node.new_by_type(['a', 'b'], [])
+      assert_instance_of(Scorpio::JSON::ArrayNode, node)
+      assert_equal(['a', 'b'], node.document)
+    end
+    it 'initializes Node' do
+      object = Object.new
+      node = Scorpio::JSON::Node.new_by_type(object, [])
+      assert_instance_of(Scorpio::JSON::Node, node)
+      assert_equal(object, node.document)
+    end
+  end
+  describe '#pointer' do
+    it 'is a ::JSON::Schema::Pointer' do
+      assert_instance_of(::JSON::Schema::Pointer, Scorpio::JSON::Node.new({}, []).pointer)
+    end
+  end
+  describe '#content' do
+    it 'returns the content at the root' do
+      assert_equal({'a' => 'b'}, Scorpio::JSON::Node.new({'a' => 'b'}, []).content)
+    end
+    it 'returns the content from the deep' do
+      assert_equal('b', Scorpio::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], [1, 'x', 0, 'a', 0]).content)
+    end
+  end
+  describe '#[]' do
+    describe 'without dereferencing' do
+      let(:node) { Scorpio::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], []) }
+      it 'subscripts arrays and hashes' do
+        assert_equal('b', node[1]['x'][0]['a'][0])
+      end
+      it 'returns ArrayNode for an array' do
+        subscripted = node[1]['x']
+        assert_instance_of(Scorpio::JSON::ArrayNode, subscripted)
+        assert_equal([{'a' => ['b']}], subscripted.content)
+        assert_equal([1, 'x'], subscripted.path)
+      end
+      it 'returns HashNode for a Hash' do
+        subscripted = node[1]
+        assert_instance_of(Scorpio::JSON::HashNode, subscripted)
+        assert_equal({'x' => [{'a' => ['b']}]}, subscripted.content)
+        assert_equal([1], subscripted.path)
+      end
+    end
+    describe 'with dereferencing' do
+      let(:document) do
+        {
+          'foo' => {'bar' => ['baz']},
+          'a' => {'$ref' => '#/foo', 'description' => 'hi'}, # not sure a description is actually allowed here, whatever
+        }
+      end
+      let(:node) { Scorpio::JSON::Node.new(document, []) }
+      it 'subscripts a node consisting of a $ref WITHOUT following' do
+        subscripted = node['a']
+        assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.content)
+        assert_equal(['a'], subscripted.path)
+      end
+      it 'follows a $ref when subscripting past it' do
+        subscripted = node['a']['bar']
+        assert_equal(['baz'], subscripted.content)
+        assert_equal(['foo', 'bar'], subscripted.path)
+      end
+      it 'does not follow a $ref when subscripting ' do
+        subscripted = node['a']['description']
+        assert_equal('hi', subscripted)
+      end
+    end
+  end
+end

--- a/test/scorpio_json_node_test.rb
+++ b/test/scorpio_json_node_test.rb
@@ -167,4 +167,10 @@ describe Scorpio::JSON::Node do
       refute_equal(Scorpio::JSON::Node.new_by_type({}, []), {})
     end
   end
+  describe '#as_json' do
+    let(:document) { {'a' => 'b'} }
+    it '#as_json' do
+      assert_equal({'a' => 'b'}, node.as_json)
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,11 @@ class ScorpioSpec < Minitest::Spec
   around do |test|
     DatabaseCleaner.cleaning { test.call }
   end
+
+  def assert_equal exp, act, msg = nil
+    msg = message(msg, E) { diff exp, act }
+    assert exp == act, msg
+  end
 end
 
 # register this to be the base class for specs instead of Minitest::Spec


### PR DESCRIPTION
extensive changes to Scorpio::JSON::HashNode and ArrayNode, extending to Scorpio::Hashlike and Arraylike, thereby affecting Scorpio::SchemaObjectBaseHash / SchemaObjectBaseArray.

full testing of JSON::Node and subclasses. not full testing of SchemaObjectBase and is ilk yet.