### PR TITLE
fixes for model base url

### DIFF
--- a/lib/scorpio/model.rb
+++ b/lib/scorpio/model.rb
@@ -266,7 +266,10 @@ module Scorpio
             "which were empty: #{empty_variables.inspect}")
         end
         path = path_template.expand(template_params)
-        url = Addressable::URI.parse(base_url) + path
+        # we do not use Addressable::URI#join as the paths should just be concatenated, not resolved.
+        # we use File.join just to deal with consecutive slashes.
+        url = File.join(base_url, path)
+        url = Addressable::URI.parse(url)
         # assume that call_params must be included somewhere. model_attributes are a source of required things
         # but not required to be here.
         other_params = call_params

--- a/test/blog.openapi.yml
+++ b/test/blog.openapi.yml
@@ -7,7 +7,7 @@ info:
   contact: {}
 host: blog
 basePath: "/v1"
-schemes: []
+schemes: ['https']
 consumes:
 - application/json
 produces:

--- a/test/blog.openapi.yml
+++ b/test/blog.openapi.yml
@@ -6,14 +6,14 @@ info:
   version: ''
   contact: {}
 host: blog
-basePath: "/"
+basePath: "/v1"
 schemes: []
 consumes:
 - application/json
 produces:
 - application/json
 paths:
-  "/v1/articles":
+  "/articles":
     get:
       operationId: articles.index
       responses:
@@ -36,7 +36,7 @@ paths:
           description: default response
           schema:
             "$ref": "#/definitions/articles"
-  "/v1/articles_with_root":
+  "/articles_with_root":
     get:
       operationId: articles.index_with_root
       responses:
@@ -53,7 +53,7 @@ paths:
                 "$ref": "#/definitions/articles"
               version:
                 type: string
-  "/v1/articles/{id}":
+  "/articles/{id}":
     get:
       operationId: articles.read
       parameters:

--- a/test/blog.rest_description.yml
+++ b/test/blog.rest_description.yml
@@ -3,19 +3,19 @@ name: blog
 title: "Scorpio Blog"
 description: "REST service for the Scorpio Blog"
 documentationLink: https://github.com/notEthan/scorpio
-servicePath: /
+servicePath: /v1
 resources:
   articles:
     methods:
       index:
-        path: v1/articles
+        path: articles
         httpMethod: GET
         response:
           type: array
           items:
             $ref: https://blog.example.com/schemas/articles/v1.0.0
       index_with_root:
-        path: v1/articles_with_root
+        path: articles_with_root
         httpMethod: GET
         response:
           type: object
@@ -29,19 +29,19 @@ resources:
             version:
               type: string
       read:
-        path: v1/articles/{id}
+        path: articles/{id}
         httpMethod: GET
         response:
           $ref: https://blog.example.com/schemas/articles/v1.0.0
       post:
-        path: v1/articles
+        path: articles
         httpMethod: POST
         request:
           $ref: https://blog.example.com/schemas/articles/v1.0.0
         response:
           $ref: https://blog.example.com/schemas/articles/v1.0.0
       patch:
-        path: v1/articles/{id}
+        path: articles/{id}
         httpMethod: PATCH
         request:
           $ref: https://blog.example.com/schemas/articles/v1.0.0

--- a/test/blog_scorpio_models.rb
+++ b/test/blog_scorpio_models.rb
@@ -3,8 +3,8 @@
 # it describes the API by setting the API document, but this class itself represents no
 # resources - it sets no resource_name and defines no schema_keys.
 class BlogModel < Scorpio::Model
-  self.base_url = 'https://blog.example.com/'
   set_openapi_document(YAML.load_file('test/blog.openapi.yml'))
+  self.base_url = File.join('https://blog.example.com/', openapi_document.basePath)
   self.faraday_request_middleware = [[:api_hammer_request_logger, Blog.logger]]
   self.faraday_adapter = [:rack, Blog.new]
 end

--- a/test/scorpio_test.rb
+++ b/test/scorpio_test.rb
@@ -49,7 +49,7 @@ describe 'blog' do
     e = assert_raises(ArgumentError) do
       Article.read({})
     end
-    assert_equal('path /v1/articles/{id} for operation articles.read requires attributes which were missing: ["id"]',
+    assert_equal('path /articles/{id} for operation articles.read requires attributes which were missing: ["id"]',
       e.message)
     e = assert_raises(ArgumentError) do
       Article.read({id: ''})


### PR DESCRIPTION
make a default #base_url getter which looks at the openapi document. fix basePath and appending other paths.