### PR TITLE
Tags

### DIFF
--- a/lib/scorpio/google_api_document.rb
+++ b/lib/scorpio/google_api_document.rb
@@ -80,13 +80,9 @@ module Scorpio
             method = http_method_methods.first
             unused_path_params = Addressable::Template.new(path).variables
             {http_method.downcase => {}.tap do |operation|
-              #operation['tags'] = []
+              operation['tags'] = method.resource_name ? [method.resource_name] : []
               #operation['summary'] = 
               operation['description'] = method['description'] if method['description']
-              if method.resource_name && options[:x]
-                operation['x-resource'] = method.resource_name
-                operation['x-resource-method'] = method.method_name
-              end
               #operation['externalDocs'] = 
               operation['operationId'] = method['id'] || (method.resource_name ? "#{method.resource_name}.#{method.method_name}" : method.method_name)
               #operation['produces'] = 

--- a/test/blog.openapi.yml
+++ b/test/blog.openapi.yml
@@ -15,6 +15,8 @@ produces:
 paths:
   "/v1/articles":
     get:
+      tags:
+      - articles
       operationId: articles.index
       responses:
         default:
@@ -24,6 +26,8 @@ paths:
             items:
               "$ref": "#/definitions/articles"
     post:
+      tags:
+      - articles
       operationId: articles.post
       parameters:
       - name: body
@@ -38,6 +42,8 @@ paths:
             "$ref": "#/definitions/articles"
   "/v1/articles_with_root":
     get:
+      tags:
+      - articles
       operationId: articles.index_with_root
       responses:
         default:
@@ -55,6 +61,8 @@ paths:
                 type: string
   "/v1/articles/{id}":
     get:
+      tags:
+      - articles
       operationId: articles.read
       parameters:
       - name: id
@@ -67,6 +75,8 @@ paths:
           schema:
             "$ref": "#/definitions/articles"
     patch:
+      tags:
+      - articles
       operationId: articles.patch
       parameters:
       - name: id

--- a/test/blog_scorpio_models.rb
+++ b/test/blog_scorpio_models.rb
@@ -13,6 +13,6 @@ end
 # to the key of the 'resources' section of the API (described by the api document
 # specified to BlogModel) 
 class Article < BlogModel
-  self.resource_name = 'articles'
+  self.tag_name = 'articles'
   self.definition_keys = ['articles']
 end


### PR DESCRIPTION
use a tag name as the main way to identify operations for a model, instead of resource_name - resource_name being a remnant of google rest description.