### PR TITLE
Typelike.as_json

### DIFF
--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -70,6 +70,9 @@ module Scorpio
   autoload :Google, 'scorpio/google_api_document'
   autoload :JSON, 'scorpio/json'
   autoload :Schema, 'scorpio/schema'
+  autoload :Typelike, 'scorpio/typelike_modules'
+  autoload :Hashlike, 'scorpio/typelike_modules'
+  autoload :Arraylike, 'scorpio/typelike_modules'
 
   class << self
     def stringify_symbol_keys(hash)

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -117,7 +117,7 @@ module Scorpio
       end
 
       def as_json
-        content.as_json
+        Typelike.as_json(content)
       end
 
       # takes a block. the block is yielded the content of this node. the block MUST return a modified
@@ -203,7 +203,7 @@ module Scorpio
       include Arraylike
 
       def as_json # needs redefined after including Enumerable
-        content.as_json
+        Typelike.as_json(content)
       end
 
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_a).
@@ -240,7 +240,7 @@ module Scorpio
       include Hashlike
 
       def as_json # needs redefined after including Enumerable
-        content.as_json
+        Typelike.as_json(content)
       end
 
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_hash)

--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -1,5 +1,3 @@
-require 'scorpio/typelike_modules'
-
 module Scorpio
   module JSON
     # Scorpio::JSON::Node is an abstraction of a node within a JSON document.

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -551,7 +551,7 @@ module Scorpio
     end
 
     def as_json
-      @attributes.as_json
+      Typelike.as_json(@attributes)
     end
 
     def inspect

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -30,7 +30,7 @@ module Scorpio
         extend SchemaObjectBaseArray
       end
       # as_json needs to be defined after we are extended by Enumerable
-      define_singleton_method(:as_json) { object.as_json }
+      define_singleton_method(:as_json) { Typelike.as_json(object) }
     end
 
     attr_reader :object


### PR DESCRIPTION
I don't have anything required that adds #as_json everywhere, but I don't really want to, so I've added Scorpio::Typelike.as_json recursive method to do it.