### PR TITLE
SchemaObjectBase#modified_copy

### DIFF
--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -76,10 +76,12 @@ module Scorpio
 
   class << self
     def stringify_symbol_keys(hash)
-      unless hash.is_a?(Hash)
+      unless hash.respond_to?(:to_hash)
         raise ArgumentError, "expected argument to be a Hash; got #{hash.class}: #{hash.pretty_inspect}"
       end
-      hash.map { |k,v| {k.is_a?(Symbol) ? k.to_s : k => v} }.inject({}, &:update)
+      Scorpio::Typelike.modified_copy(hash) do |hash_|
+        hash_.map { |k, v| {k.is_a?(Symbol) ? k.to_s : k => v} }.inject({}, &:update)
+      end
     end
   end
 

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -35,6 +35,11 @@ module Scorpio
 
     attr_reader :object
 
+    def modified_copy(&block)
+      modified_object = object.modified_copy(&block)
+      self.class.new(modified_object)
+    end
+
     def fragment
       object.fragment
     end

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -155,30 +155,6 @@ module Scorpio
         hash.merge(property_name => value)
       end
     end
-
-    def merge(other)
-      # we want to strip the containers from this before we merge
-      # this is kind of annoying. wish I had a better way.
-      other_stripped = ycomb do |striprec|
-        proc do |stripobject|
-          stripobject = stripobject.object if stripobject.is_a?(Scorpio::SchemaObjectBase)
-          stripobject = stripobject.content if stripobject.is_a?(Scorpio::JSON::Node)
-          if stripobject.is_a?(Hash)
-            stripobject.map { |k, v| {striprec.call(k) => striprec.call(v)} }.inject({}, &:update)
-          elsif stripobject.is_a?(Array)
-            stripobject.map(&striprec)
-          elsif stripobject.is_a?(Symbol)
-            stripobject.to_s
-          elsif [String, TrueClass, FalseClass, NilClass, Numeric].any? { |c| stripobject.is_a?(c) }
-            stripobject
-          else
-            raise(TypeError, "bad (not jsonifiable) object: #{stripobject.pretty_inspect}")
-          end
-        end
-      end.call(other)
-
-      self.class.new(object.merge(other_stripped))
-    end
   end
 
   module SchemaObjectBaseArray

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -209,6 +209,13 @@ module Scorpio
       end
       @object_mapped[i_]
     end
+    def []=(i, value)
+      @object = object.modified_copy do |ary|
+        ary.each_with_index.map do |el, ary_i|
+          ary_i == i ? value : el
+        end
+      end
+    end
   end
 
   def self.module_for_schema(schema_node_)

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -142,6 +142,12 @@ module Scorpio
       @object_mapped[property_name_]
     end
 
+    def []=(property_name, value)
+      @object = object.modified_copy do |hash|
+        hash.merge(property_name => value)
+      end
+    end
+
     def merge(other)
       # we want to strip the containers from this before we merge
       # this is kind of annoying. wish I had a better way.

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -238,6 +238,13 @@ module Scorpio
             define_method(property_name) do
               self[property_name]
             end
+            define_method("#{property_name}=") do |value|
+              if respond_to?(:[]=)
+                self[property_name] = value
+              else
+                raise(NoMethodError, "object does not respond to []=; cannot call accessor `#{property_name}=' for #{inspect}")
+              end
+            end
           end
         end
       end

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -126,6 +126,14 @@ module Scorpio
       define_method(method_name) { |*a, &b| object.public_send(method_name, *a, &b) }
     end
 
+    SAFE_MODIFIED_COPY_METHODS.each do |method_name|
+      define_method(method_name) do |*a, &b|
+        modified_copy do |object_to_modify|
+          object_to_modify.public_send(method_name, *a, &b)
+        end
+      end
+    end
+
     def [](property_name_)
       @object_mapped ||= Hash.new do |hash, property_name|
         hash[property_name] = begin
@@ -190,6 +198,14 @@ module Scorpio
     # we override these methods from Arraylike
     SAFE_INDEX_ONLY_METHODS.each do |method_name|
       define_method(method_name) { |*a, &b| object.public_send(method_name, *a, &b) }
+    end
+
+    SAFE_MODIFIED_COPY_METHODS.each do |method_name|
+      define_method(method_name) do |*a, &b|
+        modified_copy do |object_to_modify|
+          object_to_modify.public_send(method_name, *a, &b)
+        end
+      end
     end
 
     def [](i_)

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -1,5 +1,13 @@
 module Scorpio
   module Typelike
+    def self.modified_copy(other, &block)
+      if other.respond_to?(:modified_copy)
+        other.modified_copy(&block)
+      else
+        return yield(other)
+      end
+    end
+
     # I could require 'json/add/core' and use #as_json but I like this better.
     def self.as_json(object)
       if object.respond_to?(:to_hash)


### PR DESCRIPTION
supported by Scorpio::Typelike.modified_copy
enabling SchemaObjectBase#select, #reject, etc.
removing the need for a custom SchemaObjectBase#merge method
and supporting SchemaObjectBase#[]= and {property_name}= setters