### PR TITLE
rework how SchemaObjectBase class and module deal with Schema

### DIFF
--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -107,4 +107,5 @@ module Scorpio
       @memos[key][args_]
     end
   end
+  extend Memoize
 end

--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -97,4 +97,14 @@ module Scorpio
       fingerprint.hash
     end
   end
+
+  module Memoize
+    def memoize(key, *args_)
+      @memos ||= {}
+      @memos[key] ||= Hash.new do |h, args|
+        h[args] = yield(*args)
+      end
+      @memos[key][args_]
+    end
+  end
 end

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -477,7 +477,7 @@ module Scorpio
 
       def response_object_to_instances(object, initialize_options = {})
         if object.is_a?(SchemaObjectBase)
-          schema_as_key = object.module_schema.schema_node.content
+          schema_as_key = object.__schema__.schema_node.content
           model = models_by_schema[schema_as_key]
         end
 

--- a/lib/scorpio/schema.rb
+++ b/lib/scorpio/schema.rb
@@ -1,7 +1,17 @@
 module Scorpio
   class Schema
-    def initialize(schema_node)
-      @schema_node = schema_node
+    def initialize(schema_object)
+      if schema_object.is_a?(Scorpio::Schema)
+        raise(TypeError, "will not instantiate Schema from another Schema: #{schema_object.pretty_inspect.chomp}")
+      elsif schema_object.is_a?(Scorpio::SchemaObjectBase)
+        @schema_node = schema_object.object.deref
+      elsif schema_object.is_a?(Scorpio::JSON::HashNode)
+        @schema_node = schema_object.deref
+      elsif schema_object.respond_to?(:to_hash)
+        @schema_node = Scorpio::JSON::Node.new_by_type(schema_object, [])
+      else
+        raise(TypeError, "cannot instantiate Schema from: #{schema_object.pretty_inspect.chomp}")
+      end
     end
     attr_reader :schema_node
 

--- a/lib/scorpio/schema.rb
+++ b/lib/scorpio/schema.rb
@@ -15,8 +15,8 @@ module Scorpio
     end
     attr_reader :schema_node
 
-    def id
-      @id ||= begin
+    def schema_id
+      @schema_id ||= begin
         # start from schema_node and ascend parents looking for an 'id' property.
         # append a fragment to that id (appending to an existing fragment if there
         # is one) consisting of the path from that parent to our schema_node.
@@ -64,9 +64,9 @@ module Scorpio
         end
 
         fragment = ::JSON::Schema::Pointer.new(:reference_tokens, path_from_id_node).fragment
-        id = parent_auri.to_s + fragment
+        schema_id = parent_auri.to_s + fragment
 
-        id
+        schema_id
       end
     end
 
@@ -184,7 +184,7 @@ module Scorpio
     end
 
     def object_group_text
-      "id=#{id}"
+      "schema_id=#{schema_id}"
     end
     def inspect
       "\#<#{self.class.inspect} #{object_group_text} #{schema_node.inspect}>"

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -134,6 +134,13 @@ module Scorpio
             includer.send(:define_singleton_method, :schema) { module_schema }
           end
 
+          define_singleton_method(:id) do
+            schema.id
+          end
+          define_singleton_method(:inspect) do
+            %Q(#<Module for Schema: #{id}>)
+          end
+
           if module_schema.describes_hash?
             module_schema.described_hash_property_names.each do |property_name|
               define_method(property_name) do

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -5,17 +5,17 @@ module Scorpio
   # base class for representing an instance of an object described by a schema
   class SchemaObjectBase
     class << self
-      def id
-        schema.id
+      def schema_id
+        schema.schema_id
       end
 
       def inspect
         if !respond_to?(:schema)
           super
         elsif !name || name =~ /\AScorpio::SchemaClasses::/
-          %Q(#{SchemaClasses.inspect}[#{id.inspect}])
+          %Q(#{SchemaClasses.inspect}[#{schema_id.inspect}])
         else
-          %Q(#{name} (#{id}))
+          %Q(#{name} (#{schema_id}))
         end
       end
     end
@@ -88,8 +88,8 @@ module Scorpio
 
   # this module is just a namespace for schema classes.
   module SchemaClasses
-    def self.[](id)
-      @classes_by_id[id]
+    def self.[](schema_id)
+      @classes_by_id[schema_id]
     end
     @classes_by_id = {}
   end
@@ -108,11 +108,11 @@ module Scorpio
             begin
               include(Scorpio.module_for_schema(schema))
 
-              name = schema.id.gsub(/[^\w]/, '_')
+              name = schema.schema_id.gsub(/[^\w]/, '_')
               name = 'X' + name unless name[/\A[a-zA-Z_]/]
               name = name[0].upcase + name[1..-1]
               SchemaClasses.const_set(name, self)
-              SchemaClasses.instance_exec(id, self) { |id_, klass| @classes_by_id[id_] = klass }
+              SchemaClasses.instance_exec(self) { |klass| @classes_by_id[klass.schema_id] = klass }
 
               self
             end
@@ -138,11 +138,11 @@ module Scorpio
             includer.send(:define_singleton_method, :schema) { schema }
           end
 
-          define_singleton_method(:id) do
-            schema.id
+          define_singleton_method(:schema_id) do
+            schema.schema_id
           end
           define_singleton_method(:inspect) do
-            %Q(#<Module for Schema: #{id}>)
+            %Q(#<Module for Schema: #{schema_id}>)
           end
 
           if schema.describes_hash?


### PR DESCRIPTION
replace `#module_schema` with `#__schema__`
Schema accepts SchemaObjectBase, Node, or plain hash to initialize.
SchemaObjectBase stores a Schema instance rather than the node a schema holds.
replace Schema#id with #schema_id 

semi-related:
add Scorpio::Memoize module to help abstract memoization, replace CLASS_FOR_SCHEMA with it.
bugfix SchemaObjectBase.inspect

move module_for_schema next to class_for_schema