### PR TITLE
SchemaObjectBase accessors

### DIFF
--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -174,13 +174,17 @@ module Scorpio
           if schema.describes_hash?
             schema.described_hash_property_names.each do |property_name|
               define_method(property_name) do
-                self[property_name]
+                if respond_to?(:[])
+                  self[property_name]
+                else
+                  raise(NoMethodError, "object does not respond to []; cannot call reader `#{property_name}' for: #{pretty_inspect.chomp}")
+                end
               end
               define_method("#{property_name}=") do |value|
                 if respond_to?(:[]=)
                   self[property_name] = value
                 else
-                  raise(NoMethodError, "object does not respond to []=; cannot call accessor `#{property_name}=' for #{inspect}")
+                  raise(NoMethodError, "object does not respond to []=; cannot call writer `#{property_name}=' for: #{pretty_inspect.chomp}")
                 end
               end
             end

--- a/lib/scorpio/schema_object_base.rb
+++ b/lib/scorpio/schema_object_base.rb
@@ -172,7 +172,12 @@ module Scorpio
           end
 
           if schema.describes_hash?
-            schema.described_hash_property_names.each do |property_name|
+            instance_method_modules = [m, SchemaObjectBase, SchemaObjectBaseArray, SchemaObjectBaseHash, SchemaObjectBase::OverrideFromExtensions]
+            instance_methods = instance_method_modules.map do |mod|
+              mod.instance_methods + mod.private_instance_methods
+            end.inject(Set.new, &:|)
+            accessors_to_define = schema.described_hash_property_names.map(&:to_s) - instance_methods.map(&:to_s)
+            accessors_to_define.each do |property_name|
               define_method(property_name) do
                 if respond_to?(:[])
                   self[property_name]

--- a/test/schema_object_base_test.rb
+++ b/test/schema_object_base_test.rb
@@ -215,6 +215,13 @@ describe Scorpio::SchemaObjectBase do
         refute_respond_to(subject.baz, :to_ary)
         refute_respond_to(subject, :qux)
       end
+      describe 'when the object is not hashlike' do
+        let(:object) { nil }
+        it 'errors' do
+          err = assert_raises(NoMethodError) { subject.foo }
+          assert_match(%r(\Aobject does not respond to \[\]; cannot call reader `foo' for: #<Scorpio::SchemaClasses\["[^"]+#"\].*nil.*>\z)m, err.message)
+        end
+      end
     end
     describe 'writers' do
       it 'writes attributes describes as properties' do
@@ -235,6 +242,13 @@ describe Scorpio::SchemaObjectBase do
         assert_equal({'x' => 'y'}, orig_object['foo'].as_json)
         assert_equal({'y' => 'z'}, subject.object['foo'].as_json)
         assert_equal(orig_object.class, subject.object.class)
+      end
+      describe 'when the object is not hashlike' do
+        let(:object) { nil }
+        it 'errors' do
+          err = assert_raises(NoMethodError) { subject.foo = 0 }
+          assert_match(%r(\Aobject does not respond to \[\]=; cannot call writer `foo=' for: #<Scorpio::SchemaClasses\["[^"]+#"\].*nil.*>\z)m, err.message)
+        end
       end
     end
   end


### PR DESCRIPTION
handling error conditions. don't define methods that will (or may) conflict with methods from SchemaObjectBase or any of its included modules. and do better erroring when the object is not hashlike (or at least, does not respond to [] or []=)

with tests!