### PR TITLE
SchemaInstanceBase and friends

### DIFF
--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -73,7 +73,7 @@ module Scorpio
   autoload :OpenAPI, 'scorpio/openapi'
   autoload :Google, 'scorpio/google_api_document'
   autoload :JSON, 'scorpio/json'
-  autoload :SchemaObjectBase, 'scorpio/schema_object_base'
+  autoload :SchemaInstanceBase, 'scorpio/schema_instance_base'
   autoload :Schema, 'scorpio/schema'
   autoload :Typelike, 'scorpio/typelike_modules'
   autoload :Hashlike, 'scorpio/typelike_modules'

--- a/lib/scorpio/google_api_document.rb
+++ b/lib/scorpio/google_api_document.rb
@@ -1,5 +1,5 @@
 require 'api_hammer/ycomb'
-require 'scorpio/schema_object_base'
+require 'scorpio/schema_instance_base'
 
 module Scorpio
   module Google
@@ -21,7 +21,7 @@ module Scorpio
     # google does a weird thing where it defines a schema with a $ref property where a json-schema is to be used in the document (method request and response fields), instead of just setting the schema to be the json-schema schema. we'll share a module across those schema classes that really represent schemas. is this confusingly meta enough?
     module SchemaLike
       def to_openapi
-        dup_doc = ::JSON.parse(::JSON.generate(object.content))
+        dup_doc = ::JSON.parse(::JSON.generate(instance.content))
         # openapi does not want an id field on schemas
         dup_doc.delete('id')
         if dup_doc['properties'].is_a?(Hash)
@@ -48,7 +48,7 @@ module Scorpio
 
       def to_openapi_hash(options = {})
         # we will be modifying the api document (RestDescription). clone self and modify that one.
-        ad = self.class.new(::JSON.parse(::JSON.generate(object.document)))
+        ad = self.class.new(::JSON.parse(::JSON.generate(instance.document)))
         ad_methods = []
         if ad['methods']
           ad_methods += ad['methods'].map do |mn, m|

--- a/lib/scorpio/openapi.rb
+++ b/lib/scorpio/openapi.rb
@@ -1,4 +1,4 @@
-require 'scorpio/schema_object_base'
+require 'scorpio/schema_instance_base'
 
 module Scorpio
   module OpenAPI

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -453,7 +453,7 @@ module Scorpio
       end
 
       def response_object_to_instances(object, initialize_options = {})
-        if object.is_a?(SchemaObjectBase)
+        if object.is_a?(SchemaInstanceBase)
           model = models_by_schema[object.__schema__]
         end
 

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -349,7 +349,7 @@ module Scorpio
         if operation.responses
           _, operation_response = operation.responses.detect { |k, v| k.to_s == response.status.to_s }
           operation_response ||= operation.responses['default']
-          response_schema = operation_response.schema if operation_response
+          response_schema = operation_response['schema'] if operation_response
         end
         if response_schema
           response_object = Scorpio.class_for_schema(response_schema).new(response_object)
@@ -454,7 +454,7 @@ module Scorpio
 
       def response_object_to_instances(object, initialize_options = {})
         if object.is_a?(SchemaInstanceBase)
-          model = models_by_schema[object.__schema__]
+          model = models_by_schema[object.schema]
         end
 
         if object.respond_to?(:to_hash)

--- a/lib/scorpio/schema.rb
+++ b/lib/scorpio/schema.rb
@@ -17,7 +17,7 @@ module Scorpio
       end
       if @schema_object
         define_singleton_method(:instance) { schema_node } # aka schema_object.instance
-        define_singleton_method(:__schema__) { schema_object.__schema__ }
+        define_singleton_method(:schema) { schema_object.schema }
         extend SchemaInstanceBaseHash
       else
         define_singleton_method(:[]) { |*a, &b| schema_node.public_send(:[], *a, &b) }

--- a/lib/scorpio/schema_instance_base.rb
+++ b/lib/scorpio/schema_instance_base.rb
@@ -35,15 +35,15 @@ module Scorpio
     end
 
     def initialize(instance)
-      unless respond_to?(:__schema__)
-        raise(TypeError, "cannot instantiate #{self.class.inspect} which has no method #__schema__. please use Scorpio.class_for_schema")
+      unless respond_to?(:schema)
+        raise(TypeError, "cannot instantiate #{self.class.inspect} which has no method #schema. please use Scorpio.class_for_schema")
       end
 
       self.instance = instance
 
-      if __schema__.describes_hash? && @instance.is_a?(Scorpio::JSON::HashNode)
+      if schema.describes_hash? && @instance.is_a?(Scorpio::JSON::HashNode)
         extend SchemaInstanceBaseHash
-      elsif __schema__.describes_array? && @instance.is_a?(Scorpio::JSON::ArrayNode)
+      elsif schema.describes_array? && @instance.is_a?(Scorpio::JSON::ArrayNode)
         extend SchemaInstanceBaseArray
       end
       # certain methods need to be redefined after we are extended by Enumerable
@@ -77,13 +77,13 @@ module Scorpio
     end
 
     def fully_validate
-      __schema__.fully_validate(instance)
+      schema.fully_validate(instance)
     end
     def validate
-      __schema__.validate(instance)
+      schema.validate(instance)
     end
     def validate!
-      __schema__.validate!(instance)
+      schema.validate!(instance)
     end
     def inspect
       "\#<#{self.class.inspect} #{instance.inspect}>"
@@ -172,7 +172,7 @@ module Scorpio
     memoize(:module_for_schema, schema__) do |schema_|
       Module.new.tap do |m|
         m.instance_exec(schema_) do |schema|
-          define_method(:__schema__) { schema }
+          define_method(:schema) { schema }
           define_singleton_method(:schema) { schema }
           define_singleton_method(:included) do |includer|
             includer.send(:define_singleton_method, :schema) { schema }
@@ -243,7 +243,7 @@ module Scorpio
     def [](property_name_)
       @instance_mapped ||= Hash.new do |hash, property_name|
         hash[property_name] = begin
-          property_schema = __schema__.subschema_for_property(property_name)
+          property_schema = schema.subschema_for_property(property_name)
           property_schema = property_schema && property_schema.match_to_instance(instance[property_name])
 
           if property_schema && instance[property_name].is_a?(JSON::Node)
@@ -295,7 +295,7 @@ module Scorpio
       # constructor, so it's a hash with integer keys
       @instance_mapped ||= Hash.new do |hash, i|
         hash[i] = begin
-          index_schema = __schema__.subschema_for_index(i)
+          index_schema = schema.subschema_for_index(i)
           index_schema = index_schema && index_schema.match_to_instance(instance[i])
 
           if index_schema && instance[i].is_a?(JSON::Node)

--- a/test/schema_instance_base_array_test.rb
+++ b/test/schema_instance_base_array_test.rb
@@ -1,11 +1,11 @@
 require_relative 'test_helper'
 
-describe Scorpio::SchemaObjectBaseArray do
+describe Scorpio::SchemaInstanceBaseArray do
   let(:document) do
     ['foo', {'lamp' => [3]}, ['q', 'r']]
   end
   let(:path) { [] }
-  let(:object) { Scorpio::JSON::Node.new_by_type(document, path) }
+  let(:instance) { Scorpio::JSON::Node.new_by_type(document, path) }
   let(:schema_content) do
     {
       'type' => 'array',
@@ -18,7 +18,7 @@ describe Scorpio::SchemaObjectBaseArray do
   end
   let(:schema) { Scorpio::Schema.new(schema_content) }
   let(:class_for_schema) { Scorpio.class_for_schema(schema) }
-  let(:subject) { class_for_schema.new(object) }
+  let(:subject) { class_for_schema.new(instance) }
 
   describe 'arraylike []=' do
     it 'sets an index' do
@@ -30,18 +30,18 @@ describe Scorpio::SchemaObjectBaseArray do
       assert_instance_of(Scorpio.class_for_schema(schema.schema_node['items'][2]), orig_2)
       assert_instance_of(Scorpio.class_for_schema(schema.schema_node['items'][2]), subject[2])
     end
-    it 'updates to a modified copy of the object without altering the original' do
-      orig_object = subject.object
+    it 'updates to a modified copy of the instance without altering the original' do
+      orig_instance = subject.instance
 
       subject[2] = {'y' => 'z'}
 
-      refute_equal(orig_object, subject.object)
-      assert_equal(['q', 'r'], orig_object[2].as_json)
-      assert_equal({'y' => 'z'}, subject.object[2].as_json)
-      assert_equal(orig_object.class, subject.object.class)
+      refute_equal(orig_instance, subject.instance)
+      assert_equal(['q', 'r'], orig_instance[2].as_json)
+      assert_equal({'y' => 'z'}, subject.instance[2].as_json)
+      assert_equal(orig_instance.class, subject.instance.class)
     end
-    describe 'when the object is not arraylike' do
-      let(:object) { nil }
+    describe 'when the instance is not arraylike' do
+      let(:instance) { nil }
       it 'errors' do
         err = assert_raises(NoMethodError) { subject[2] = 0 }
         assert_match(%r(\Aundefined method `\[\]=' for #<Scorpio::SchemaClasses::X.*>\z), err.message)
@@ -65,7 +65,7 @@ describe Scorpio::SchemaObjectBaseArray do
     it('#<=>')                  { assert_equal(-1, [] <=> subject) }
     require 'abbrev'
     it('#abbrev')               { assert_equal({'a' => 'a'}, class_for_schema.new(['a']).abbrev) }
-    it('#assoc')                { assert_equal(['q', 'r'], subject.object.assoc('q')) }
+    it('#assoc')                { assert_equal(['q', 'r'], subject.instance.assoc('q')) }
     it('#at')                   { assert_equal('foo', subject.at(0)) }
     it('#bsearch')              { assert_equal(nil, subject.bsearch { false }) }
     it('#bsearch_index')        { assert_equal(nil, subject.bsearch_index { false }) } if [].respond_to?(:bsearch_index)
@@ -92,7 +92,7 @@ describe Scorpio::SchemaObjectBaseArray do
     # assoc:  https://github.com/ruby/ruby/blob/v2_5_0/array.c#L3780-L3813
     # rassoc: https://github.com/ruby/ruby/blob/v2_5_0/array.c#L3815-L3847
     # for this reason, rassoc is NOT defined on Arraylike and #content must be called.
-    it('#rassoc')               { assert_equal(['q', 'r'], subject.object.content.rassoc('r')) }
+    it('#rassoc')               { assert_equal(['q', 'r'], subject.instance.content.rassoc('r')) }
     it('#repeated_combination') { assert_equal([[]], subject.repeated_combination(0).to_a) }
     it('#repeated_permutation') { assert_equal([[]], subject.repeated_permutation(0).to_a) }
     it('#reverse')              { assert_equal([subject[2], subject[1], 'foo'], subject.reverse) }

--- a/test/schema_instance_base_hash_test.rb
+++ b/test/schema_instance_base_hash_test.rb
@@ -1,11 +1,11 @@
 require_relative 'test_helper'
 
-describe Scorpio::SchemaObjectBaseHash do
+describe Scorpio::SchemaInstanceBaseHash do
   let(:document) do
     {'foo' => {'x' => 'y'}, 'bar' => [9], 'baz' => true}
   end
   let(:path) { [] }
-  let(:object) { Scorpio::JSON::Node.new_by_type(document, path) }
+  let(:instance) { Scorpio::JSON::Node.new_by_type(document, path) }
   let(:schema_content) do
     {
       'type' => 'object',
@@ -16,7 +16,7 @@ describe Scorpio::SchemaObjectBaseHash do
   end
   let(:schema) { Scorpio::Schema.new(schema_content) }
   let(:class_for_schema) { Scorpio.class_for_schema(schema) }
-  let(:subject) { class_for_schema.new(object) }
+  let(:subject) { class_for_schema.new(instance) }
 
   describe 'hashlike []=' do
     it 'sets a property' do
@@ -28,18 +28,18 @@ describe Scorpio::SchemaObjectBaseHash do
       assert_instance_of(Scorpio.class_for_schema(schema.schema_node['properties']['foo']), orig_foo)
       assert_instance_of(Scorpio.class_for_schema(schema.schema_node['properties']['foo']), subject['foo'])
     end
-    it 'updates to a modified copy of the object without altering the original' do
-      orig_object = subject.object
+    it 'updates to a modified copy of the instance without altering the original' do
+      orig_instance = subject.instance
 
       subject['foo'] = {'y' => 'z'}
 
-      refute_equal(orig_object, subject.object)
-      assert_equal({'x' => 'y'}, orig_object['foo'].as_json)
-      assert_equal({'y' => 'z'}, subject.object['foo'].as_json)
-      assert_equal(orig_object.class, subject.object.class)
+      refute_equal(orig_instance, subject.instance)
+      assert_equal({'x' => 'y'}, orig_instance['foo'].as_json)
+      assert_equal({'y' => 'z'}, subject.instance['foo'].as_json)
+      assert_equal(orig_instance.class, subject.instance.class)
     end
-    describe 'when the object is not hashlike' do
-      let(:object) { nil }
+    describe 'when the instance is not hashlike' do
+      let(:instance) { nil }
       it 'errors' do
         err = assert_raises(NoMethodError) { subject['foo'] = 0 }
         assert_match(%r(\Aundefined method `\[\]=' for #<Scorpio::SchemaClasses::X.*>\z), err.message)

--- a/test/schema_instance_base_test.rb
+++ b/test/schema_instance_base_test.rb
@@ -95,7 +95,7 @@ describe Scorpio::SchemaInstanceBase do
     describe 'on Base' do
       it 'errors' do
         err = assert_raises(TypeError) { Scorpio::SchemaInstanceBase.new({}) }
-        assert_equal('cannot instantiate Scorpio::SchemaInstanceBase which has no method #__schema__. please use Scorpio.class_for_schema', err.message)
+        assert_equal('cannot instantiate Scorpio::SchemaInstanceBase which has no method #schema. please use Scorpio.class_for_schema', err.message)
       end
     end
     describe 'nil' do
@@ -253,7 +253,7 @@ describe Scorpio::SchemaInstanceBase do
               'each' => {},           # SchemaInstanceBaseHash / SchemaInstanceBaseArray
               'instance_exec' => {},  # BasicObject
               'instance' => {},       # SchemaInstanceBase
-              '__schema__' => {},     # module_for_schema singleton definition
+              'schema' => {},         # module_for_schema singleton definition
             },
           }
         end
@@ -267,12 +267,12 @@ describe Scorpio::SchemaInstanceBase do
             'each' => 'hi',
             'instance_exec' => 'hi',
             'instance' => 'hi',
-            '__schema__' => 'hi',
+            'schema' => 'hi',
           }
         end
         it 'does not define readers' do
           assert_equal('bar', subject.foo)
-          assert_equal(Scorpio.module_for_schema(subject.__schema__), subject.method(:foo).owner)
+          assert_equal(Scorpio.module_for_schema(subject.schema), subject.method(:foo).owner)
 
           assert_equal(Scorpio::SchemaInstanceBase, subject.method(:initialize).owner)
           assert_equal('hi', subject['initialize'])
@@ -283,7 +283,7 @@ describe Scorpio::SchemaInstanceBase do
           assert_equal(subject, subject.each { })
           assert_equal(2, subject.instance_exec { 2 })
           assert_equal(instance, subject.instance)
-          assert_equal(schema, subject.__schema__)
+          assert_equal(schema, subject.schema)
         end
       end
     end

--- a/test/schema_instance_base_test.rb
+++ b/test/schema_instance_base_test.rb
@@ -1,15 +1,15 @@
 require_relative 'test_helper'
 
-describe Scorpio::SchemaObjectBase do
+describe Scorpio::SchemaInstanceBase do
   let(:document) { {} }
   let(:path) { [] }
-  let(:object) { Scorpio::JSON::Node.new_by_type(document, path) }
+  let(:instance) { Scorpio::JSON::Node.new_by_type(document, path) }
   let(:schema_content) { {} }
   let(:schema) { Scorpio::Schema.new(schema_content) }
-  let(:subject) { Scorpio.class_for_schema(schema).new(object) }
+  let(:subject) { Scorpio.class_for_schema(schema).new(instance) }
   describe 'class .inspect' do
     it 'is the same as Class#inspect on the base' do
-      assert_equal('Scorpio::SchemaObjectBase', Scorpio::SchemaObjectBase.inspect)
+      assert_equal('Scorpio::SchemaInstanceBase', Scorpio::SchemaInstanceBase.inspect)
     end
     it 'is SchemaClasses[] for generated subclass without id' do
       assert_match(%r(\AScorpio::SchemaClasses\["[a-f0-9\-]+#"\]\z), subject.class.inspect)
@@ -25,9 +25,9 @@ describe Scorpio::SchemaObjectBase do
     end
   end
   describe 'class name' do
-    let(:schema_content) { {'id' => 'https://scorpio/SchemaObjectBaseTest'} }
+    let(:schema_content) { {'id' => 'https://scorpio/SchemaInstanceBaseTest'} }
     it 'generates a class name from schema_id' do
-      assert_equal('Scorpio::SchemaClasses::Https___scorpio_SchemaObjectBaseTest_', subject.class.name)
+      assert_equal('Scorpio::SchemaClasses::Https___scorpio_SchemaInstanceBaseTest_', subject.class.name)
     end
     it 'uses an existing name' do
       assert_equal('Scorpio::OpenAPI::V2::Operation', Scorpio::OpenAPI::V2::Operation.name)
@@ -63,7 +63,7 @@ describe Scorpio::SchemaObjectBase do
       class_for_schema = Scorpio.class_for_schema(schema)
       # same class every time
       assert_equal(Scorpio.class_for_schema(schema), class_for_schema)
-      assert_operator(class_for_schema, :<, Scorpio::SchemaObjectBase)
+      assert_operator(class_for_schema, :<, Scorpio::SchemaInstanceBase)
     end
     it 'returns a class from a hash' do
       assert_equal(Scorpio.class_for_schema(schema), Scorpio.class_for_schema(schema.schema_node.content))
@@ -71,7 +71,7 @@ describe Scorpio::SchemaObjectBase do
     it 'returns a class from a schema node' do
       assert_equal(Scorpio.class_for_schema(schema), Scorpio.class_for_schema(schema.schema_node))
     end
-    it 'returns a class from a SchemaObjectBase' do
+    it 'returns a class from a SchemaInstanceBase' do
       assert_equal(Scorpio.class_for_schema(schema), Scorpio.class_for_schema(Scorpio.class_for_schema({}).new(schema.schema_node)))
     end
   end
@@ -87,38 +87,38 @@ describe Scorpio::SchemaObjectBase do
     it 'returns a module from a schema node' do
       assert_equal(Scorpio.module_for_schema(schema), Scorpio.module_for_schema(schema.schema_node))
     end
-    it 'returns a module from a SchemaObjectBase' do
+    it 'returns a module from a SchemaInstanceBase' do
       assert_equal(Scorpio.module_for_schema(schema), Scorpio.module_for_schema(Scorpio.class_for_schema({}).new(schema.schema_node)))
     end
   end
   describe 'initialization' do
     describe 'on Base' do
       it 'errors' do
-        err = assert_raises(TypeError) { Scorpio::SchemaObjectBase.new({}) }
-        assert_equal('cannot instantiate Scorpio::SchemaObjectBase which has no method #__schema__. please use Scorpio.class_for_schema', err.message)
+        err = assert_raises(TypeError) { Scorpio::SchemaInstanceBase.new({}) }
+        assert_equal('cannot instantiate Scorpio::SchemaInstanceBase which has no method #__schema__. please use Scorpio.class_for_schema', err.message)
       end
     end
     describe 'nil' do
-      let(:object) { nil }
-      it 'initializes with nil object' do
-        assert_equal(Scorpio::JSON::Node.new_by_type(nil, []), subject.object)
+      let(:instance) { nil }
+      it 'initializes with nil instance' do
+        assert_equal(Scorpio::JSON::Node.new_by_type(nil, []), subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
     end
-    describe 'arbitrary object' do
-      let(:object) { Object.new }
+    describe 'arbitrary instance' do
+      let(:instance) { Object.new }
       it 'initializes' do
-        assert_equal(Scorpio::JSON::Node.new_by_type(object, []), subject.object)
+        assert_equal(Scorpio::JSON::Node.new_by_type(instance, []), subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
     end
     describe 'hash' do
-      let(:object) { {'foo' => 'bar'} }
+      let(:instance) { {'foo' => 'bar'} }
       let(:schema_content) { {'type' => 'object'} }
       it 'initializes' do
-        assert_equal(Scorpio::JSON::Node.new_by_type({'foo' => 'bar'}, []), subject.object)
+        assert_equal(Scorpio::JSON::Node.new_by_type({'foo' => 'bar'}, []), subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(subject.respond_to?(:to_hash))
       end
@@ -127,16 +127,16 @@ describe Scorpio::SchemaObjectBase do
       let(:document) { {'foo' => 'bar'} }
       let(:schema_content) { {'type' => 'object'} }
       it 'initializes' do
-        assert_equal(Scorpio::JSON::HashNode.new({'foo' => 'bar'}, []), subject.object)
+        assert_equal(Scorpio::JSON::HashNode.new({'foo' => 'bar'}, []), subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(subject.respond_to?(:to_hash))
       end
     end
     describe 'array' do
-      let(:object) { ['foo'] }
+      let(:instance) { ['foo'] }
       let(:schema_content) { {'type' => 'array'} }
       it 'initializes' do
-        assert_equal(Scorpio::JSON::Node.new_by_type(['foo'], []), subject.object)
+        assert_equal(Scorpio::JSON::Node.new_by_type(['foo'], []), subject.instance)
         assert(subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
@@ -145,29 +145,29 @@ describe Scorpio::SchemaObjectBase do
       let(:document) { ['foo'] }
       let(:schema_content) { {'type' => 'array'} }
       it 'initializes' do
-        assert_equal(Scorpio::JSON::ArrayNode.new(['foo'], []), subject.object)
+        assert_equal(Scorpio::JSON::ArrayNode.new(['foo'], []), subject.instance)
         assert(subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
     end
   end
   describe '#modified_copy' do
-    describe 'with an object that does have #modified_copy' do
-      it 'yields the object to modify' do
+    describe 'with an instance that does have #modified_copy' do
+      it 'yields the instance to modify' do
         modified = subject.modified_copy do |o|
           assert_equal({}, o)
           {'a' => 'b'}
         end
-        assert_equal({'a' => 'b'}, modified.object.content)
-        assert_equal({}, subject.object.content)
-        refute_equal(object, modified)
+        assert_equal({'a' => 'b'}, modified.instance.content)
+        assert_equal({}, subject.instance.content)
+        refute_equal(instance, modified)
       end
     end
     describe 'no modification' do
-      it 'yields the object to modify' do
+      it 'yields the instance to modify' do
         modified = subject.modified_copy { |o| o }
         # this doesn't really need to be tested but ... whatever
-        assert_equal(subject.object.content.object_id, modified.object.content.object_id)
+        assert_equal(subject.instance.content.object_id, modified.instance.content.object_id)
         assert_equal(subject, modified)
         refute_equal(subject.object_id, modified.object_id)
       end
@@ -179,14 +179,14 @@ describe Scorpio::SchemaObjectBase do
         modified = subject.modified_copy do |o|
           o.to_s
         end
-        assert_equal('{}', modified.object.content)
-        assert_equal({}, subject.object.content)
-        refute_equal(object, modified)
+        assert_equal('{}', modified.instance.content)
+        assert_equal({}, subject.instance.content)
+        refute_equal(instance, modified)
         # interesting side effect
         assert(subject.respond_to?(:to_hash))
         assert(!modified.respond_to?(:to_hash))
-        assert_equal(Scorpio::JSON::HashNode, subject.object.class)
-        assert_equal(Scorpio::JSON::Node, modified.object.class)
+        assert_equal(Scorpio::JSON::HashNode, subject.instance.class)
+        assert_equal(Scorpio::JSON::Node, modified.instance.class)
       end
     end
   end
@@ -233,11 +233,11 @@ describe Scorpio::SchemaObjectBase do
         refute_respond_to(subject.baz, :to_ary)
         refute_respond_to(subject, :qux)
       end
-      describe 'when the object is not hashlike' do
-        let(:object) { nil }
+      describe 'when the instance is not hashlike' do
+        let(:instance) { nil }
         it 'errors' do
           err = assert_raises(NoMethodError) { subject.foo }
-          assert_match(%r(\Aobject does not respond to \[\]; cannot call reader `foo' for: #<Scorpio::SchemaClasses\["[^"]+#"\].*nil.*>\z)m, err.message)
+          assert_match(%r(\Ainstance does not respond to \[\]; cannot call reader `foo' for: #<Scorpio::SchemaClasses\["[^"]+#"\].*nil.*>\z)m, err.message)
         end
       end
       describe 'properties with the same names as instance methods' do
@@ -246,13 +246,13 @@ describe Scorpio::SchemaObjectBase do
             'type' => 'object',
             'properties' => {
               'foo' => {},            # not an instance method
-              'initialize' => {},     # SchemaObjectBase
-              'inspect' => {},        # SchemaObjectBase
+              'initialize' => {},     # SchemaInstanceBase
+              'inspect' => {},        # SchemaInstanceBase
               'pretty_inspect' => {}, # Kernel
-              'as_json' => {},        # SchemaObjectBase::OverrideFromExtensions, extended on initialization
-              'each' => {},           # SchemaObjectBaseHash / SchemaObjectBaseArray
+              'as_json' => {},        # SchemaInstanceBase::OverrideFromExtensions, extended on initialization
+              'each' => {},           # SchemaInstanceBaseHash / SchemaInstanceBaseArray
               'instance_exec' => {},  # BasicObject
-              'object' => {},         # SchemaObjectBase
+              'instance' => {},       # SchemaInstanceBase
               '__schema__' => {},     # module_for_schema singleton definition
             },
           }
@@ -266,7 +266,7 @@ describe Scorpio::SchemaObjectBase do
             'as_json' => 'hi',
             'each' => 'hi',
             'instance_exec' => 'hi',
-            'object' => 'hi',
+            'instance' => 'hi',
             '__schema__' => 'hi',
           }
         end
@@ -274,7 +274,7 @@ describe Scorpio::SchemaObjectBase do
           assert_equal('bar', subject.foo)
           assert_equal(Scorpio.module_for_schema(subject.__schema__), subject.method(:foo).owner)
 
-          assert_equal(Scorpio::SchemaObjectBase, subject.method(:initialize).owner)
+          assert_equal(Scorpio::SchemaInstanceBase, subject.method(:initialize).owner)
           assert_equal('hi', subject['initialize'])
           assert_match(%r(\A#\{<Scorpio::SchemaClasses\[".*#"\].*}\z)m, subject.inspect)
           assert_equal('hi', subject['inspect'])
@@ -282,7 +282,7 @@ describe Scorpio::SchemaObjectBase do
           assert_equal(document, subject.as_json)
           assert_equal(subject, subject.each { })
           assert_equal(2, subject.instance_exec { 2 })
-          assert_equal(object, subject.object)
+          assert_equal(instance, subject.instance)
           assert_equal(schema, subject.__schema__)
         end
       end
@@ -297,21 +297,21 @@ describe Scorpio::SchemaObjectBase do
         assert_instance_of(Scorpio.class_for_schema(schema.schema_node['properties']['foo']), orig_foo)
         assert_instance_of(Scorpio.class_for_schema(schema.schema_node['properties']['foo']), subject.foo)
       end
-      it 'updates to a modified copy of the object without altering the original' do
-        orig_object = subject.object
+      it 'updates to a modified copy of the instance without altering the original' do
+        orig_instance = subject.instance
 
         subject.foo = {'y' => 'z'}
 
-        refute_equal(orig_object, subject.object)
-        assert_equal({'x' => 'y'}, orig_object['foo'].as_json)
-        assert_equal({'y' => 'z'}, subject.object['foo'].as_json)
-        assert_equal(orig_object.class, subject.object.class)
+        refute_equal(orig_instance, subject.instance)
+        assert_equal({'x' => 'y'}, orig_instance['foo'].as_json)
+        assert_equal({'y' => 'z'}, subject.instance['foo'].as_json)
+        assert_equal(orig_instance.class, subject.instance.class)
       end
-      describe 'when the object is not hashlike' do
-        let(:object) { nil }
+      describe 'when the instance is not hashlike' do
+        let(:instance) { nil }
         it 'errors' do
           err = assert_raises(NoMethodError) { subject.foo = 0 }
-          assert_match(%r(\Aobject does not respond to \[\]=; cannot call writer `foo=' for: #<Scorpio::SchemaClasses\["[^"]+#"\].*nil.*>\z)m, err.message)
+          assert_match(%r(\Ainstance does not respond to \[\]=; cannot call writer `foo=' for: #<Scorpio::SchemaClasses\["[^"]+#"\].*nil.*>\z)m, err.message)
         end
       end
     end
@@ -333,18 +333,18 @@ describe Scorpio::SchemaObjectBase do
       assert_equal(['a', 'b'], Scorpio.class_for_schema({'type' => 'array'}).new(Scorpio::JSON::Node.new_by_type(['a', 'b'], [])).as_json)
     end
   end
-  describe 'ridiculous way to test object= getting the wrong type' do
+  describe 'ridiculous way to test instance= getting the wrong type' do
     # this error message indicates an internal bug (hence Bug class), so there isn't an intended way to
-    # trigger it using SchemaObjectBase properly. we use it improperly just to test that code path. this
+    # trigger it using SchemaInstanceBase properly. we use it improperly just to test that code path. this
     # is definitely not defined behavior.
     #
     # make thing whose #modified_copy behaves incorrectly, to abuse the internals of []=
     let(:schema_content) { {'type' => 'object'} }
 
     it 'errors' do
-      subject.object.define_singleton_method(:modified_copy) { |*_a| [] }
+      subject.instance.define_singleton_method(:modified_copy) { |*_a| [] }
       err = assert_raises(Scorpio::Bug) { subject['foo'] = 'bar' }
-      assert_match(%r(\Awill not accept object of different class Array to current object class Scorpio::JSON::HashNode on Scorpio::SchemaClasses\["[a-z0-9\-]+#"\]\z), err.message)
+      assert_match(%r(\Awill not accept instance of different class Array to current instance class Scorpio::JSON::HashNode on Scorpio::SchemaClasses\["[a-z0-9\-]+#"\]\z), err.message)
     end
   end
 end

--- a/test/schema_object_base_test.rb
+++ b/test/schema_object_base_test.rb
@@ -339,14 +339,10 @@ describe Scorpio::SchemaObjectBase do
     # is definitely not defined behavior.
     #
     # make thing whose #modified_copy behaves incorrectly, to abuse the internals of []=
-    let(:object) do
-      Scorpio::JSON::HashNode.new({}, []).tap do |object|
-        object.define_singleton_method(:modified_copy) { |*_a| [] }
-      end
-    end
     let(:schema_content) { {'type' => 'object'} }
 
     it 'errors' do
+      subject.object.define_singleton_method(:modified_copy) { |*_a| [] }
       err = assert_raises(Scorpio::Bug) { subject['foo'] = 'bar' }
       assert_match(%r(\Awill not accept object of different class Array to current object class Scorpio::JSON::HashNode on Scorpio::SchemaClasses\["[a-z0-9\-]+#"\]\z), err.message)
     end


### PR DESCRIPTION
better naming
replace /`SchemaObjectBase`/`SchemaInstanceBase`/
replace its /`#object`/`#instance`/
also replace /`#__schema__`/`#schema`/

happy @edan?