### PR TITLE
refactor Typelike modified copy methods

### DIFF
--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -214,15 +214,6 @@ module Scorpio
       SAFE_INDEX_ONLY_METHODS.each do |method_name|
         define_method(method_name) { |*a, &b| content.public_send(method_name, *a, &b) }
       end
-
-      # methods that return a modified copy
-      SAFE_MODIFIED_COPY_METHODS.each do |method_name|
-        define_method(method_name) do |*a, &b|
-          modified_copy do |content_to_modify|
-            content_to_modify.public_send(method_name, *a, &b)
-          end
-        end
-      end
     end
 
     class HashNode < Node
@@ -249,15 +240,6 @@ module Scorpio
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_hash)
       SAFE_KEY_ONLY_METHODS.each do |method_name|
         define_method(method_name) { |*a, &b| content.public_send(method_name, *a, &b) }
-      end
-
-      # methods that return a modified copy
-      SAFE_MODIFIED_COPY_METHODS.each do |method_name|
-        define_method(method_name) do |*a, &b|
-          modified_copy do |content_to_modify|
-            content_to_modify.public_send(method_name, *a, &b)
-          end
-        end
       end
     end
   end

--- a/lib/scorpio/schema_instance_base.rb
+++ b/lib/scorpio/schema_instance_base.rb
@@ -232,14 +232,6 @@ module Scorpio
       define_method(method_name) { |*a, &b| instance.public_send(method_name, *a, &b) }
     end
 
-    SAFE_MODIFIED_COPY_METHODS.each do |method_name|
-      define_method(method_name) do |*a, &b|
-        modified_copy do |instance_to_modify|
-          instance_to_modify.public_send(method_name, *a, &b)
-        end
-      end
-    end
-
     def [](property_name_)
       @instance_mapped ||= Hash.new do |hash, property_name|
         hash[property_name] = begin
@@ -280,14 +272,6 @@ module Scorpio
     # we override these methods from Arraylike
     SAFE_INDEX_ONLY_METHODS.each do |method_name|
       define_method(method_name) { |*a, &b| instance.public_send(method_name, *a, &b) }
-    end
-
-    SAFE_MODIFIED_COPY_METHODS.each do |method_name|
-      define_method(method_name) do |*a, &b|
-        modified_copy do |instance_to_modify|
-          instance_to_modify.public_send(method_name, *a, &b)
-        end
-      end
     end
 
     def [](i_)

--- a/test/schema_instance_base_array_test.rb
+++ b/test/schema_instance_base_array_test.rb
@@ -113,7 +113,15 @@ describe Scorpio::SchemaInstanceBaseArray do
   end
   describe 'modified copy methods' do
     it('#reject')  { assert_equal(class_for_schema.new(Scorpio::JSON::ArrayNode.new(['foo'], [])), subject.reject { |e| e != 'foo' }) }
+    it('#reject block var') do
+      subj_a = subject.to_a
+      subject.reject { |e| assert_equal(e, subj_a.shift) }
+    end
     it('#select')  { assert_equal(class_for_schema.new(Scorpio::JSON::ArrayNode.new(['foo'], [])), subject.select { |e| e == 'foo' }) }
+    it('#select block var') do
+      subj_a = subject.to_a
+      subject.select { |e| assert_equal(e, subj_a.shift) }
+    end
     it('#compact') { assert_equal(subject, subject.compact) }
     describe 'at a depth' do
       let(:document) { [['b', 'q'], {'c' => ['d', 'e']}] }

--- a/test/schema_instance_base_hash_test.rb
+++ b/test/schema_instance_base_hash_test.rb
@@ -76,6 +76,7 @@ describe Scorpio::SchemaInstanceBaseHash do
     it('#rassoc')       { assert_equal(['baz', true], subject.rassoc(true)) }
     it('#to_h')         { assert_equal({'foo' => subject['foo'], 'bar' => subject['bar'], 'baz' => true}, subject.to_h) }
     it('#to_proc')      { assert_equal(true, subject.to_proc.call('baz')) } if {}.respond_to?(:to_proc)
+    it('#transform_values') { assert_equal({'foo' => nil, 'bar' => nil, 'baz' => nil}, subject.transform_values { |_| nil}) }
     it('#value?')       { assert_equal(false, subject.value?('0')) }
     it('#values')       { assert_equal([subject['foo'], subject['bar'], true], subject.values) }
     it('#values_at')    { assert_equal([true], subject.values_at('baz')) }
@@ -84,9 +85,15 @@ describe Scorpio::SchemaInstanceBaseHash do
     # I'm going to rely on the #merge test above to test the modified copy functionality and just do basic
     # tests of all the modified copy methods here
     it('#merge')            { assert_equal(subject, subject.merge({})) }
-    it('#transform_values') { assert_equal(class_for_schema.new(Scorpio::JSON::HashNode.new({'foo' => nil, 'bar' => nil, 'baz' => nil}, [])), subject.transform_values { |_| nil}) }
     it('#reject')           { assert_equal(class_for_schema.new(Scorpio::JSON::HashNode.new({}, [])), subject.reject { true }) }
     it('#select')           { assert_equal(class_for_schema.new(Scorpio::JSON::HashNode.new({}, [])), subject.select { false }) }
+    describe '#select' do
+      it 'yields properly too' do
+        subject.select do |k, v|
+          assert_equal(subject[k], v)
+        end
+      end
+    end
     # Hash#compact only available as of ruby 2.5.0
     if {}.respond_to?(:compact)
       it('#compact')        { assert_equal(subject, subject.compact) }

--- a/test/scorpio_json_hashnode_test.rb
+++ b/test/scorpio_json_hashnode_test.rb
@@ -90,6 +90,7 @@ describe Scorpio::JSON::HashNode do
     it('#rassoc')       { assert_equal(['a', 'b'], node.rassoc('b')) }
     it('#to_h')         { assert_equal({'a' => 'b', 'c' => node['c']}, node.to_h) }
     it('#to_proc')      { assert_equal('b', node.to_proc.call('a')) } if {}.respond_to?(:to_proc)
+    it('#transform_values') { assert_equal({'a' => nil, 'c' => nil}, node.transform_values { |_| nil}) }
     it('#value?')       { assert_equal(false, node.value?('0')) }
     it('#values')       { assert_equal(['b', node['c']], node.values) }
     it('#values_at')    { assert_equal(['b'], node.values_at('a')) }
@@ -98,7 +99,6 @@ describe Scorpio::JSON::HashNode do
     # I'm going to rely on the #merge test above to test the modified copy functionality and just do basic
     # tests of all the modified copy methods here
     it('#merge')            { assert_equal(node, node.merge({})) }
-    it('#transform_values') { assert_equal(Scorpio::JSON::Node.new_by_type({'a' => nil, 'c' => nil}, []), node.transform_values { |_| nil}) }
     it('#reject')           { assert_equal(Scorpio::JSON::Node.new_by_type({}, []), node.reject { true }) }
     it('#select')           { assert_equal(Scorpio::JSON::Node.new_by_type({}, []), node.select { false }) }
     # Hash#compact only available as of ruby 2.5.0


### PR DESCRIPTION
drop Typelike SAFE_MODIFIED_COPY_METHODS. implement Hashlike#select, #reject, #compact, #merge. implement Arraylike #select, #reject, #compact. no longer implement #transform_values to return a modified copy.

this fixes an issue where Hashlike#select and #reject returned a modified copy (a SchemaInstanceBase or JSON::HashNode) but the block variables were from the underlying hash, instead of the receiver.

transform_values isn't practical to return a modified copy because putting block result into the typelike object is ... weird.