### PR TITLE
SchemaInstanceBase#inspect lower verbosity

### DIFF
--- a/lib/scorpio/schema_instance_base.rb
+++ b/lib/scorpio/schema_instance_base.rb
@@ -18,6 +18,15 @@ module Scorpio
           %Q(#{name} (#{schema_id}))
         end
       end
+      def to_s
+        if !respond_to?(:schema)
+          super
+        elsif !name || name =~ /\AScorpio::SchemaClasses::/
+          %Q(#{SchemaClasses.inspect}[#{schema_id.inspect}])
+        else
+          name
+        end
+      end
 
       def schema_classes_const_name
         name = schema.schema_id.gsub(/[^\w]/, '_')
@@ -86,11 +95,11 @@ module Scorpio
       schema.validate!(instance)
     end
     def inspect
-      "\#<#{self.class.inspect} #{instance.inspect}>"
+      "\#<#{self.class.to_s} #{instance.inspect}>"
     end
     def pretty_print(q)
       q.instance_exec(self) do |obj|
-        text "\#<#{obj.class.inspect}"
+        text "\#<#{obj.class.to_s}"
         group_sub {
           nest(2) {
             breakable ' '
@@ -103,7 +112,7 @@ module Scorpio
     end
 
     def object_group_text
-      instance.class.inspect + ' ' + instance.object_group_text
+      instance.object_group_text
     end
 
     def fingerprint

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -67,7 +67,7 @@ module Scorpio
 
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''
-      "\#{<#{self.class.inspect}#{object_group_text}>#{empty? ? '' : ' '}#{self.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(', ')}}"
+      "\#{<#{self.class.to_s}#{object_group_text}>#{empty? ? '' : ' '}#{self.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(', ')}}"
     end
 
     def to_s
@@ -77,7 +77,7 @@ module Scorpio
     def pretty_print(q)
       q.instance_exec(self) do |obj|
         object_group_text = obj.respond_to?(:object_group_text) ? ' ' + obj.object_group_text : ''
-        text "\#{<#{obj.class.inspect}#{object_group_text}>"
+        text "\#{<#{obj.class.to_s}#{object_group_text}>"
         group_sub {
           nest(2) {
             breakable(obj.any? { true } ? ' ' : '')
@@ -133,7 +133,7 @@ module Scorpio
 
     def inspect
       object_group_text = respond_to?(:object_group_text) ? ' ' + self.object_group_text : ''
-      "\#[<#{self.class.inspect}#{object_group_text}>#{empty? ? '' : ' '}#{self.map { |e| e.inspect }.join(', ')}]"
+      "\#[<#{self.class.to_s}#{object_group_text}>#{empty? ? '' : ' '}#{self.map { |e| e.inspect }.join(', ')}]"
     end
 
     def to_s
@@ -143,7 +143,7 @@ module Scorpio
     def pretty_print(q)
       q.instance_exec(self) do |obj|
         object_group_text = obj.respond_to?(:object_group_text) ? ' ' + obj.object_group_text : ''
-        text "\#[<#{obj.class.inspect}#{object_group_text}>"
+        text "\#[<#{obj.class.to_s}#{object_group_text}>"
         group_sub {
           nest(2) {
             breakable(obj.any? { true } ? ' ' : '')


### PR DESCRIPTION
lowering the verbosity of SchemaInstanceBase#inspect. only show the schema id if the class is not explicitly named, and drop the class of the instance