### PR TITLE
SIB decorates hash / array by underlying type only, not schema

### DIFF
--- a/lib/scorpio/schema_instance_base.rb
+++ b/lib/scorpio/schema_instance_base.rb
@@ -52,9 +52,9 @@ module Scorpio
 
       self.instance = instance
 
-      if schema.describes_hash? && @instance.is_a?(Scorpio::JSON::HashNode)
+      if @instance.is_a?(Scorpio::JSON::HashNode)
         extend SchemaInstanceBaseHash
-      elsif schema.describes_array? && @instance.is_a?(Scorpio::JSON::ArrayNode)
+      elsif @instance.is_a?(Scorpio::JSON::ArrayNode)
         extend SchemaInstanceBaseArray
       end
       # certain methods need to be redefined after we are extended by Enumerable

--- a/test/schema_instance_base_test.rb
+++ b/test/schema_instance_base_test.rb
@@ -317,13 +317,17 @@ describe Scorpio::SchemaInstanceBase do
     end
   end
   describe '#inspect' do
+    # if the instance is hash-like, #inspect gets overridden
+    let(:document) { Object.new }
     it 'inspects' do
-      assert_match(%r(\A#<Scorpio::SchemaClasses\["[^"]+#"\] #\{<Scorpio::JSON::HashNode fragment="#">\}>\z), subject.inspect)
+      assert_match(%r(\A#<Scorpio::SchemaClasses\["[^"]+#"\] #<Scorpio::JSON::Node fragment="#" #<Object:[^<>]*>>>\z), subject.inspect)
     end
   end
   describe '#pretty_print' do
+    # if the instance is hash-like, #pretty_print gets overridden
+    let(:document) { Object.new }
     it 'pretty_prints' do
-      assert_match(%r(\A#<Scorpio::SchemaClasses\["[^"]+#"\]\n  #\{<Scorpio::JSON::HashNode fragment="#">\}\n>\z), subject.pretty_inspect.chomp)
+      assert_match(%r(\A#<Scorpio::SchemaClasses\["[^"]+#"\]\n  #<Scorpio::JSON::Node fragment="#" #<Object:[^<>]*>>\n>\z), subject.pretty_inspect.chomp)
     end
   end
   describe '#as_json' do


### PR DESCRIPTION
no longer checking schema.describes_hash? / schema.describes_array? on SchemaInstanceBase initialize to decide to extend with SchemaInstanceBaseHash / SchemaInstanceBaseArray.
