### PR TITLE
add #as_json options

### DIFF
--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -114,8 +114,8 @@ module Scorpio
         pointer.fragment
       end
 
-      def as_json
-        Typelike.as_json(content)
+      def as_json(*opt)
+        Typelike.as_json(content, *opt)
       end
 
       # takes a block. the block is yielded the content of this node. the block MUST return a modified
@@ -205,8 +205,8 @@ module Scorpio
 
       include Arraylike
 
-      def as_json # needs redefined after including Enumerable
-        Typelike.as_json(content)
+      def as_json(*opt) # needs redefined after including Enumerable
+        Typelike.as_json(content, *opt)
       end
 
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_a).
@@ -233,8 +233,8 @@ module Scorpio
 
       include Hashlike
 
-      def as_json # needs redefined after including Enumerable
-        Typelike.as_json(content)
+      def as_json(*opt) # needs redefined after including Enumerable
+        Typelike.as_json(content, *opt)
       end
 
       # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_hash)

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -534,8 +534,8 @@ module Scorpio
       response
     end
 
-    def as_json
-      Typelike.as_json(@attributes)
+    def as_json(*opt)
+      Typelike.as_json(@attributes, *opt)
     end
 
     def inspect

--- a/lib/scorpio/schema_instance_base.rb
+++ b/lib/scorpio/schema_instance_base.rb
@@ -62,8 +62,8 @@ module Scorpio
     end
 
     module OverrideFromExtensions
-      def as_json
-        Typelike.as_json(instance)
+      def as_json(*opt)
+        Typelike.as_json(instance, *opt)
       end
     end
 

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -9,24 +9,24 @@ module Scorpio
     end
 
     # I could require 'json/add/core' and use #as_json but I like this better.
-    def self.as_json(object)
+    def self.as_json(object, *opt)
       if object.respond_to?(:to_hash)
         object.map do |k, v|
           unless k.is_a?(Symbol) || k.respond_to?(:to_str)
             raise(TypeError, "json object (hash) cannot be keyed with: #{k.pretty_inspect.chomp}")
           end
-          {k.to_s => as_json(v)}
+          {k.to_s => as_json(v, *opt)}
         end.inject({}, &:update)
       elsif object.respond_to?(:to_ary)
-        object.map { |e| as_json(e) }
+        object.map { |e| as_json(e, *opt) }
       elsif [String, TrueClass, FalseClass, NilClass, Numeric].any? { |c| object.is_a?(c) }
         object
       elsif object.is_a?(Symbol)
         object.to_s
       elsif object.is_a?(Set)
-        as_json(object.to_a)
+        as_json(object.to_a, *opt)
       elsif object.respond_to?(:as_json)
-        as_json(object.as_json)
+        as_json(object.as_json(*opt), *opt)
       else
         raise(TypeError, "cannot express object as json: #{object.pretty_inspect.chomp}")
       end

--- a/test/schema_instance_base_test.rb
+++ b/test/schema_instance_base_test.rb
@@ -335,6 +335,7 @@ describe Scorpio::SchemaInstanceBase do
       assert_equal({'a' => 'b'}, Scorpio.class_for_schema({}).new(Scorpio::JSON::Node.new_by_type({'a' => 'b'}, [])).as_json)
       assert_equal({'a' => 'b'}, Scorpio.class_for_schema({'type' => 'object'}).new(Scorpio::JSON::Node.new_by_type({'a' => 'b'}, [])).as_json)
       assert_equal(['a', 'b'], Scorpio.class_for_schema({'type' => 'array'}).new(Scorpio::JSON::Node.new_by_type(['a', 'b'], [])).as_json)
+      assert_equal(['a'], Scorpio::class_for_schema({}).new(['a']).as_json(some_option: true))
     end
   end
   describe 'ridiculous way to test instance= getting the wrong type' do

--- a/test/scorpio_json_arraynode_test.rb
+++ b/test/scorpio_json_arraynode_test.rb
@@ -45,6 +45,7 @@ describe Scorpio::JSON::ArrayNode do
     let(:document) { ['a', 'b'] }
     it '#as_json' do
       assert_equal(['a', 'b'], node.as_json)
+      assert_equal(['a', 'b'], node.as_json(some_option: false))
     end
   end
   # these methods just delegate to Array so not going to test excessively

--- a/test/scorpio_json_hashnode_test.rb
+++ b/test/scorpio_json_hashnode_test.rb
@@ -58,6 +58,7 @@ describe Scorpio::JSON::HashNode do
     let(:document) { {'a' => 'b'} }
     it '#as_json' do
       assert_equal({'a' => 'b'}, node.as_json)
+      assert_equal({'a' => 'b'}, node.as_json(this_option: 'what?'))
     end
   end
   # these methods just delegate to Hash so not going to test excessively


### PR DESCRIPTION
add argument(s) to #as_json for options, for compatibility with activesupport and maybe other as_json implementations - we don't use these options but pass them along where appropriate