### PR TITLE
SIB#parents, #parent

### DIFF
--- a/lib/scorpio/openapi.rb
+++ b/lib/scorpio/openapi.rb
@@ -138,8 +138,18 @@ module Scorpio
       JsonReference               = openapi_class.call('definitions', 'jsonReference')
 
       class Operation
-        attr_accessor :path
-        attr_accessor :http_method
+        attr_writer :path
+        attr_writer :http_method
+        def path
+          @path ||= if parent.is_a?(Scorpio::OpenAPI::V2::PathItem) && parent.parent.is_a?(Scorpio::OpenAPI::V2::Paths)
+            parent.instance.path.last
+          end
+        end
+        def http_method
+          @http_method ||= if parent.is_a?(Scorpio::OpenAPI::V2::PathItem)
+            instance.path.last
+          end
+        end
 
         # there should only be one body parameter; this returns it
         def body_parameter

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -128,8 +128,6 @@ module Scorpio
             unless operation.is_a?(Scorpio::OpenAPI::V2::Operation)
               raise("bad operation at #{operation.fragment}: #{operation.pretty_inspect}")
             end
-            operation.path = path
-            operation.http_method = http_method
           end
         end
 
@@ -217,8 +215,6 @@ module Scorpio
         openapi_document.paths.each do |path, path_item|
           path_item.each do |http_method, operation|
             next if http_method == 'parameters' # parameters is not an operation. TOOD maybe just select the keys that are http methods?
-            operation.path = path
-            operation.http_method = http_method
             method_name = method_names_by_operation[operation]
             # class method
             if operation_for_resource_class?(operation) && !respond_to?(method_name)

--- a/test/schema_instance_base_test.rb
+++ b/test/schema_instance_base_test.rb
@@ -151,6 +151,28 @@ describe Scorpio::SchemaInstanceBase do
       end
     end
   end
+  describe '#parents, #parent' do
+    let(:schema_content) { {properties: {foo: {properties: {bar: {properties: {baz: {}}}}}}} }
+    let(:document) { {foo: {bar: {baz: {}}}} }
+    describe 'no parents' do
+      it 'has none' do
+        assert_equal([], subject.parents)
+        assert_equal(nil, subject.parent)
+      end
+    end
+    describe 'one parent' do
+      it 'has one' do
+        assert_equal([subject], subject.foo.parents)
+        assert_equal(subject, subject.foo.parent)
+      end
+    end
+    describe 'more parents' do
+      it 'has more' do
+        assert_equal([subject.foo.bar, subject.foo, subject], subject.foo.bar.baz.parents)
+        assert_equal(subject.foo.bar, subject.foo.bar.baz.parent)
+      end
+    end
+  end
   describe '#modified_copy' do
     describe 'with an instance that does have #modified_copy' do
       it 'yields the instance to modify' do


### PR DESCRIPTION
add #parents. use this to find the path and http_method of an Operation, rather than explicitly storing it. these methods will be needed for more things later.