### PR TITLE
include enumerable

### DIFF
--- a/lib/scorpio/json/node.rb
+++ b/lib/scorpio/json/node.rb
@@ -203,6 +203,7 @@ module Scorpio
         to_a
       end
 
+      include Enumerable
       include Arraylike
 
       def as_json(*opt) # needs redefined after including Enumerable
@@ -231,6 +232,7 @@ module Scorpio
         inject({}) { |h, (k, v)| h[k] = v; h }
       end
 
+      include Enumerable
       include Hashlike
 
       def as_json(*opt) # needs redefined after including Enumerable

--- a/lib/scorpio/typelike_modules.rb
+++ b/lib/scorpio/typelike_modules.rb
@@ -33,8 +33,6 @@ module Scorpio
     end
   end
   module Hashlike
-    include Enumerable
-
     # safe methods which can be delegated to #to_hash (which the includer is assumed to have defined).
     # 'safe' means, in this context, nondestructive - methods which do not modify the receiver.
 
@@ -99,8 +97,6 @@ module Scorpio
     end
   end
   module Arraylike
-    include Enumerable
-
     # safe methods which can be delegated to #to_ary (which the includer is assumed to have defined).
     # 'safe' means, in this context, nondestructive - methods which do not modify the receiver.
 

--- a/test/schema_instance_base_test.rb
+++ b/test/schema_instance_base_test.rb
@@ -173,6 +173,13 @@ describe Scorpio::SchemaInstanceBase do
       end
     end
   end
+  describe '#each, Enumerable methods' do
+    let(:document) { 'a string' }
+    it "raises NoMethodError calling each or Enumerable methods" do
+      assert_raises(NoMethodError) { subject.each { nil } }
+      assert_raises(NoMethodError) { subject.map { nil } }
+    end
+  end
   describe '#modified_copy' do
     describe 'with an instance that does have #modified_copy' do
       it 'yields the instance to modify' do


### PR DESCRIPTION
extending SIB at #initialize with Enumerable causes problems. SIB will always include Enumerable but raise NoMethodError from #each. 