### PR TITLE
Revert "minitest-reporters v1.3.0 for now, v1.3.1 is broken"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gem 'activerecord', '~> 4.0' # until I decide ruby 2.1 is too old
 gem 'byebug'
 gem 'coveralls_reborn', '~> 0.11'
 gem 'wwtd'
-gem 'minitest-reporters', '= 1.3.0' # temporary: v1.3.1 is broken; remove when fix released


### PR DESCRIPTION
This reverts commit 46fb40c304584e00f99a9d6e2a91792daa2f87d0.