### PR TITLE
don't validate openapi_document in ResourceBase

### DIFF
--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -131,7 +131,7 @@ module Scorpio
           end
         end
 
-        openapi_document.validate!
+        # TODO blame validate openapi_document
 
         update_dynamic_methods
       end


### PR DESCRIPTION
rm ResourceBase call to validate! its openapi_document on set. this is slow and unnecessary, and blame handling will do it better in the future.