### PR TITLE
set param

### DIFF
--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -94,6 +94,12 @@ module Scorpio
   include HTTPErrors
   error_classes_by_status.freeze
 
+  class ConfigError < Error
+    attr_accessor :name
+  end
+  class AmbiguousParameter < ConfigError
+  end
+
   autoload :Google, 'scorpio/google_api_document'
   autoload :OpenAPI, 'scorpio/openapi'
   autoload :Ur, 'scorpio/ur'

--- a/lib/scorpio/openapi/operation.rb
+++ b/lib/scorpio/openapi/operation.rb
@@ -85,6 +85,27 @@ module Scorpio
         end
       end
 
+      # this method is not intended to be API-stable at the moment.
+      #
+      # @return [#to_ary<#to_h>] the parameters specified for this operation, plus any others
+      #   scorpio considers to be parameters
+      def inferred_parameters
+        parameters = self.parameters ? self.parameters.to_a.dup : []
+        path_template.variables.each do |var|
+          unless parameters.any? { |p| p['in'] == 'path' && p['name'] == var }
+            # we could instantiate this as a V2::Parameter or a V3::Parameter
+            # or a ParameterWithContentInPath or whatever. but I can't be bothered.
+            parameters << {
+              'name' => var,
+              'in' => 'path',
+              'required' => true,
+              'type' => 'string',
+            }
+          end
+        end
+        parameters
+      end
+
       def build_request(*a, &b)
         request = Scorpio::Request.new(self, *a, &b)
       end

--- a/lib/scorpio/request.rb
+++ b/lib/scorpio/request.rb
@@ -138,6 +138,8 @@ module Scorpio
         end
       end
 
+      extend operation.request_accessor_module
+
       if block_given?
         yield self
       end


### PR DESCRIPTION
a request will support top-level config keys to #initialize, as well as accessors, named after unambiguously named parameters of the operation