### PR TITLE
jsi v0.3

### DIFF
--- a/documents/github.com/OAI/OpenAPI-Specification/blob/oas3-schema/schemas/v3.0/schema.yaml
+++ b/documents/github.com/OAI/OpenAPI-Specification/blob/oas3-schema/schemas/v3.0/schema.yaml
@@ -40,6 +40,14 @@ definitions:
       '^\$ref$':
         type: string
         format: uri-reference
+  SchemaReference:
+    type: object
+    required:
+      - $ref
+    patternProperties:
+      '^\$ref$':
+        type: string
+        format: uri-reference
   Info:
     type: object
     required:
@@ -135,7 +143,7 @@ definitions:
         patternProperties:
           '^[a-zA-Z0-9\.\-_]+$':
             oneOf:
-              - $ref: '#/definitions/Reference'
+              - $ref: '#/definitions/SchemaReference'
               - $ref: '#/definitions/Schema'
       responses:
         type: object
@@ -266,39 +274,39 @@ definitions:
       not:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       allOf:
         type: array
         items:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       oneOf:
         type: array
         items:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       anyOf:
         type: array
         items:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       items:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       properties:
         type: object
         additionalProperties:
           oneOf:
             - $ref: '#/definitions/Schema'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
       additionalProperties:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
           - type: boolean
         default: true
       description:
@@ -399,7 +407,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
       encoding:
         type: object
@@ -417,7 +425,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       examples:
         type: object
         additionalProperties:
@@ -486,7 +494,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
     patternProperties:
       '^x-': {}
@@ -522,7 +530,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       examples:
         type: object
         additionalProperties:
@@ -769,7 +777,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
     patternProperties:
       '^x-': {}
@@ -815,7 +823,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
     patternProperties:
       '^x-': {}
@@ -858,7 +866,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
     patternProperties:
       '^x-': {}
@@ -901,7 +909,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       example: {}
     patternProperties:
       '^x-': {}
@@ -956,13 +964,13 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       examples:
         type: object
         additionalProperties:
           oneOf:
             - $ref: '#/definitions/Example'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
     patternProperties:
       '^x-': {}
     additionalProperties: false
@@ -1008,13 +1016,13 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       examples:
         type: object
         additionalProperties:
           oneOf:
             - $ref: '#/definitions/Example'
-            - $ref: '#/definitions/Reference'
+            - $ref: '#/definitions/SchemaReference'
     patternProperties:
       '^x-': {}
     additionalProperties: false    
@@ -1057,7 +1065,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       examples:
         type: object
         additionalProperties:
@@ -1106,7 +1114,7 @@ definitions:
       schema:
         oneOf:
           - $ref: '#/definitions/Schema'
-          - $ref: '#/definitions/Reference'
+          - $ref: '#/definitions/SchemaReference'
       examples:
         type: object
         additionalProperties:

--- a/lib/scorpio/google_api_document.rb
+++ b/lib/scorpio/google_api_document.rb
@@ -1,10 +1,7 @@
 module Scorpio
   module Google
-    discovery_rest_description_doc = JSI::JSON::Node.new_doc(::JSON.parse(Scorpio.root.join('documents/www.googleapis.com/discovery/v1/apis/discovery/v1/rest').read))
-
-    discovery_metaschema = discovery_rest_description_doc['schemas']['JsonSchema']
-    rest_description_schema = JSI.class_for_schema(discovery_metaschema).new(discovery_rest_description_doc['schemas']['RestDescription'])
-    discovery_rest_description = JSI.class_for_schema(rest_description_schema).new(discovery_rest_description_doc)
+    discovery_rest_description_doc = ::JSON.parse(Scorpio.root.join('documents/www.googleapis.com/discovery/v1/apis/discovery/v1/rest').read)
+    discovery_rest_description = JSI::MetaschemaNode.new(discovery_rest_description_doc, metaschema_root_ptr: JSI::JSON::Pointer['schemas']['JsonSchema'], root_schema_ptr: JSI::JSON::Pointer['schemas']['RestDescription'])
 
     # naming these is not strictly necessary, but is nice to have.
     DirectoryList      = JSI.class_for_schema(discovery_rest_description['schemas']['DirectoryList'])

--- a/lib/scorpio/openapi.rb
+++ b/lib/scorpio/openapi.rb
@@ -24,9 +24,10 @@ module Scorpio
 
       # naming these is not strictly necessary, but is nice to have.
       # generated: `puts JSI::Schema.new(::YAML.load_file(Scorpio.root.join('documents/github.com/OAI/OpenAPI-Specification/blob/oas3-schema/schemas/v3.0/schema.yaml')))['definitions'].select { |k,v| ['object', nil].include?(v['type']) }.keys.map { |k| "#{k[0].upcase}#{k[1..-1]} = openapi_class.call('definitions', '#{k}')" }`
-      Reference  = openapi_class.call('definitions', 'Reference')
-      Info        = openapi_class.call('definitions', 'Info')
-      Contact      = openapi_class.call('definitions', 'Contact')
+      Reference      = openapi_class.call('definitions', 'Reference')
+      SchemaReference = openapi_class.call('definitions', 'SchemaReference')
+      Info           = openapi_class.call('definitions', 'Info')
+      Contact       = openapi_class.call('definitions', 'Contact')
       License       = openapi_class.call('definitions', 'License')
       Server         = openapi_class.call('definitions', 'Server')
       ServerVariable  = openapi_class.call('definitions', 'ServerVariable')

--- a/lib/scorpio/openapi.rb
+++ b/lib/scorpio/openapi.rb
@@ -12,6 +12,7 @@ module Scorpio
 
     autoload :Operation, 'scorpio/openapi/operation'
     autoload :Document, 'scorpio/openapi/document'
+    autoload :Reference, 'scorpio/openapi/reference'
     autoload :OperationsScope, 'scorpio/openapi/operations_scope'
 
     module V3
@@ -173,6 +174,9 @@ module Scorpio
       class Document
         include OpenAPI::Document
       end
+      class Reference
+        include OpenAPI::Reference
+      end
       require 'scorpio/openapi/v3/server'
     end
 
@@ -182,6 +186,9 @@ module Scorpio
       end
       class Document
         include OpenAPI::Document
+      end
+      class JsonReference
+        include OpenAPI::Reference
       end
     end
   end

--- a/lib/scorpio/openapi.rb
+++ b/lib/scorpio/openapi.rb
@@ -85,6 +85,11 @@ module Scorpio
       LinkWithOperationId     = openapi_class.call('definitions', 'LinkWithOperationId')
       Callback               = openapi_class.call('definitions', 'Callback')
       Encoding              = openapi_class.call('definitions', 'Encoding')
+
+      # the schema of Scorpio::OpenAPI::V3::Schema describes a schema itself, so we extend it
+      # with the module indicating that.
+      Schema.schema.extend(JSI::Schema::DescribesSchema)
+      SchemaReference.schema.extend(JSI::Schema::DescribesSchema)
     end
     module V2
       openapi_schema = JSI::Schema.new(::JSON.parse(Scorpio.root.join('documents/swagger.io/v2/schema.json').read))
@@ -150,6 +155,10 @@ module Scorpio
       UniqueItems = openapi_class.call('definitions', 'uniqueItems')
       Enum         = openapi_class.call('definitions', 'enum')
       JsonReference = openapi_class.call('definitions', 'jsonReference')
+
+      # the schema of Scorpio::OpenAPI::V2::Schema describes a schema itself, so we extend it
+      # with the module indicating that.
+      Schema.schema.extend(JSI::Schema::DescribesSchema)
     end
 
     begin

--- a/lib/scorpio/openapi/operations_scope.rb
+++ b/lib/scorpio/openapi/operations_scope.rb
@@ -27,7 +27,7 @@ module Scorpio
       # @return [Scorpio::OpenAPI::Operation] the operation with the given operationId
       # @raise [::KeyError] if the given operationId does not exist
       def [](operationId)
-        memoize(:[], operationId) do |operationId_|
+        jsi_memoize(:[], operationId) do |operationId_|
           detect { |operation| operation.operationId == operationId_ }.tap do |op|
             unless op
               raise(::KeyError, "operationId not found: #{operationId_.inspect}")

--- a/lib/scorpio/openapi/reference.rb
+++ b/lib/scorpio/openapi/reference.rb
@@ -1,6 +1,19 @@
 module Scorpio
   module OpenAPI
     module Reference
+      # overrides JSI::Base#[] to implicitly dereference this Reference, except when
+      # the given token is present in this Reference's instance (this should usually
+      # only apply to the token '$ref')
+      #
+      # see JSI::Base#initialize documentation at https://www.rubydoc.info/gems/jsi/JSI/Base
+      def [](token, *a, &b)
+        if respond_to?(:to_hash) && !key?(token)
+          deref do |deref_jsi|
+            return deref_jsi[token]
+          end
+        end
+        return super
+      end
     end
   end
 end

--- a/lib/scorpio/openapi/reference.rb
+++ b/lib/scorpio/openapi/reference.rb
@@ -1,0 +1,6 @@
+module Scorpio
+  module OpenAPI
+    module Reference
+    end
+  end
+end

--- a/lib/scorpio/resource_base.rb
+++ b/lib/scorpio/resource_base.rb
@@ -519,7 +519,7 @@ module Scorpio
       end
     end
 
-    def fingerprint
+    def jsi_fingerprint
       {class: self.class, attributes: JSI::Typelike.as_json(@attributes)}
     end
     include JSI::FingerprintHash

--- a/lib/scorpio/response.rb
+++ b/lib/scorpio/response.rb
@@ -22,7 +22,7 @@ module Scorpio
         end
 
         if response_schema && (body_object.respond_to?(:to_hash) || body_object.respond_to?(:to_ary))
-          body_object = JSI.class_for_schema(response_schema).new(body_object)
+          body_object = response_schema.new_jsi(body_object)
         end
 
         body_object

--- a/scorpio.gemspec
+++ b/scorpio.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jsi", "~> 0.2.0"
+  spec.add_dependency "jsi", "~> 0.3.0"
   spec.add_dependency "ur", "~> 0.1.0"
   spec.add_dependency "faraday"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
- `Scorpio::OpenAPI::Reference` no longer references schemas
- `Scorpio::OpenAPI::V3::SchemaReference` references schemas (and describes a schema itself). don't need this for V2 because a `$ref` is normally a schema there, not a `V2::JsonReference`
- `Scorpio::OpenAPI::Reference` (included by `Scorpio::OpenAPI::V3::Reference` and `Scorpio::OpenAPI::V2::JsonReference`) implicitly derefs to what it's pointed at when you subscript
- `Scorpio::Google::JsonSchema` is a `JSI::Metaschema` (why am I still updating this?)
